### PR TITLE
Added physchem qualifiers (without unit)

### DIFF
--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -28,9 +28,9 @@
   }
 `
  propertiesSparql = `
-SELECT ?propEntity ?propEntityLabel ?value ?units ?unitsLabel ?source ?sourceLabel ?doi
+SELECT DISTINCT ?propEntity ?propEntityLabel ?value ?units ?unitsLabel ?qualifiers ?source ?sourceLabel ?doi
 WITH {
-  SELECT DISTINCT ?propEntity ?value ?units ?source ?doi WHERE {
+  SELECT DISTINCT ?propEntity ?value ?units ?source ?doi (GROUP_CONCAT(?qualifierStr; separator=", ") AS ?qualifiers) WHERE {
     wd:{{ q }} ?propp ?statement .
     ?statement a wikibase:BestRank ;
       ?proppsv [
@@ -45,13 +45,29 @@ WITH {
             wikibase:statementValue ?proppsv ;
             wdt:P1629 ?propEntity ;
             wdt:P31 wd:Q21077852 .
-  }
+    OPTIONAL {
+      {
+        ?qualifierProp wikibase:qualifier ?qualifier ;
+                       rdfs:label ?qProplabel; FILTER (lang(?qProplabel) = "en") .
+        ?qualifier a owl:DatatypeProperty .
+        ?statement ?qualifier ?qualifierVal .
+        BIND (CONCAT(str(?qProplabel), ": ", str(?qualifierVal)) AS ?qualifierStr)
+      } UNION {
+        ?qualifierProp wikibase:qualifier ?qualifier ;
+                       rdfs:label ?qProplabel; FILTER (lang(?qProplabel) = "en") .
+        ?qualifier a owl:ObjectProperty .
+        ?statement ?qualifier ?qualifierVal .
+        ?qualifierVal rdfs:label ?qVallabel; FILTER (lang(?qVallabel) = "en") .
+        BIND (CONCAT(str(?qProplabel), ": ", str(?qVallabel)) AS ?qualifierStr)
+      }
+    }
+  } GROUP BY ?propEntity ?value ?units ?source ?doi
 } AS %result
 WHERE {
   INCLUDE %result
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 } 
-ORDER BY ASC(?IDpredLabel)
+ORDER BY ASC(?propEntityLabel)
 `
 
  $(document).ready(function() {


### PR DESCRIPTION
Chemical can have multiple, for example, boiling points, under different conditions. The latter are modeled as qualifiers in Wikidata and now added. Units are still missing, and I may do that later, but people can look that up, but it clarifies enough why there are multiple values for 'boiling point'.