### PR TITLE
Remove note from co-author graph

### DIFF
--- a/scholia/app/templates/authors.html
+++ b/scholia/app/templates/authors.html
@@ -32,8 +32,6 @@
 
 <h2 id="Co-author graph">Co-author graph</h2>
 
-(Does not work with five or more authors)
-
 <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0APREFIX%20gas%3A%20%3Chttp%3A%2F%2Fwww.bigdata.com%2Frdf%2Fgas%23%3E%0A%0ASELECT%20%3Fauthor%20%3FauthorLabel%20%3Fwork%20%3FworkLabel%20%0AWITH%20%7B%0A%20SELECT%20%3Fwork%20%3Fauthor%20WHERE%20%7B%20%0A%20%20%7B%20%7D%0A%20%20{% for q1 in qs %} {% for q2 in qs %} {% if q1 < q2 %} UNION%20%7B%0A%20%20%20SELECT%20%3Fwork%20%3Fauthor%20WHERE%20%7B%0A%20%20%20%20SERVICE%20gas%3Aservice%20%7B%0A%20%20%20%20%20gas%3Aprogram%20gas%3AgasClass%20%22com.bigdata.rdf.graph.analytics.BFS%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3Ain%20wd:{{ q1 }}%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3Atarget%20wd:{{ q2 }}%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3AtraversalDirection%20%22Undirected%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3Aout%20%3Fwork%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3AlinkType%20wdt%3AP50%20%3B%0A%20%20%20%20%7D%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%0A%20%20%20%7D%0A%20%20%7D%20%23%20UNION%20END%0A  {% endif %} {% endfor %}  {% endfor %} %20%7D%20%0A%7D%20AS%20%25result%20%0AWHERE%20%7B%0A%20INCLUDE%20%25result%20%0A%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Che%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%20"></iframe>
 </div>


### PR DESCRIPTION
The Wikidata Query Service UI, including the embed version, now retries queries with POST if the GET request fails because they’re too long (this was implemented in [Ic3ea53c50e][1]), so there is no hard limit on the number of authors. (The query sometimes fails for other reasons, but that can also happen with less than five authors.)

[1]: https://gerrit.wikimedia.org/r/#/c/355131/