### PR TITLE
Add link to Wikipedia article

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -46,14 +46,15 @@
       catch(e) {}
       
       var title = item.sitelinks.enwiki.title;
-      var wikipediaUrl = 'https://en.wikipedia.org/w/api.php?' +
+      var wikipediaApiUrl = 'https://en.wikipedia.org/w/api.php?' +
 	  'action=query&prop=extracts&exsentences=3&exlimit=1&exintro=1&' + 
 	  'explaintext=1&callback=?&format=json&titles=' +
 	  encodeURIComponent(title);
+      var wikipediaUrl = 'https://en.wikipedia.org/wiki/' + encodeURIComponent(title)
       
-      $.getJSON(wikipediaUrl, function(data) {
+      $.getJSON(wikipediaApiUrl, function(data) {
 	  var pages = data.query.pages;
-	  var text = pages[Object.keys(pages)[0]].extract + " ... (from the English Wikipedia)";
+	  var text = pages[Object.keys(pages)[0]].extract + " ... (from the <a href=\"" + wikipediaUrl + "\">English Wikipedia</a>)";
 	  $("#intro").text(text);
       }).fail(function(d, textStatus, error) {
 	  console.error("getJSON failed, status: " + textStatus + ", error: "+error)


### PR DESCRIPTION
Currently, I think there is no direct link from any Scholia page to the Wikipedia article, even though it *is* referenced. I can't test right now, but it seems like a trivial change.