### PR TITLE
Fixed getting the classes of things (closes #275)

### DIFF
--- a/scholia/query.py
+++ b/scholia/query.py
@@ -246,7 +246,7 @@ def q_to_class(q):
     is compared against a set of hardcoded matches.
 
     """
-    query = 'select ?class where {{ wd:{q} wdt:P31 ?class }}'.format(
+    query = 'select ?class where {{ wd:{q} p:P31/ps:P31 ?class }}'.format(
         q=escape_string(q))
 
     url = 'https://query.wikidata.org/sparql'


### PR DESCRIPTION
Apparently, wdt:P31 only gets a subset of classes when priorities are used. For example,
acetic acid has "carboxylic acid" as higher priority class, so that at an RDF level
only that one is given. We have, however, access to all classes via the statements.