### PR TITLE
Add year of award if only given by start time (P580)

### DIFF
--- a/scholia/app/templates/award.html
+++ b/scholia/app/templates/award.html
@@ -11,13 +11,15 @@ SELECT
   ?recipient ?recipientLabel 
   ?example_work ?example_workLabel
 WITH {
-  SELECT ?recipient ?year (SAMPLE(?work) AS ?example_work) WHERE {
+  SELECT DISTINCT ?recipient ?year (SAMPLE(?work) AS ?example_work) WHERE {
     ?recipient p:P166 ?award_statement . 
     ?award_statement ps:P166 wd:{{ q }} .
     OPTIONAL {
-      ?award_statement pq:P585 ?time .
-	  BIND(YEAR(?time) AS ?year)
-	}
+      { ?award_statement pq:P585 ?time }
+      UNION
+      { ?award_statement pq:P580 ?time }
+      BIND(YEAR(?time) AS ?year)
+    }
     OPTIONAL { ?work wdt:P50 ?recipient . }
   }
   GROUP BY ?recipient ?year


### PR DESCRIPTION
For instance <https://tools.wmflabs.org/scholia/award/Q42092479> (the scholarship is awared for time spans such as 2018/2019).