### PR TITLE
fix Wikidata Query Service link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -16,7 +16,7 @@ Scholia is mainly based on
 -  JavaScript with `jQuery <https://jquery.com/>`__ and
    `wikidata-sdk <https://github.com/maxlath/wikidata-sdk>`__
 -  SPARQL to query the `Wikidata Query
-   Service <http://query.wikidata,org/>`__
+   Service <http://query.wikidata.org/>`__
 
 Getting started
 ---------------


### PR DESCRIPTION
The link is invalid because a comma is used instead of a dot, with this change the link should be directly accessible again.

We are going to use Scholia as a part of a software project at my university, there might be future contributions to Scholia if we have anything meaningful.