### PR TITLE
Fix #795: Remove link to SourceMd

### DIFF
--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -341,7 +341,10 @@ ORDER BY ?publication_date
 <table class="table table-hover" id="list-of-publications"></table>
 
 
-<div>
+<!--      SourceMD does currently not work
+
+div>
+
 
     Missing publications? 
     {% if first_initial and last_name %}
@@ -352,7 +355,7 @@ ORDER BY ?publication_date
     Add new ones with <a href="https://tools.wmflabs.org/sourcemd/">sourcemd</a>.
     {% endif %}
     
-</div>
+</div -->
 
 
 <h3 id="Number of publications per year">Number of publications per year</h3>

--- a/scholia/app/templates/faq.html
+++ b/scholia/app/templates/faq.html
@@ -16,7 +16,11 @@
 	If not, add a new data item with the
 	<a href="https://www.wikidata.org/wiki/Special:NewItem">new item page</a> on the Wikidata site.
 	<br/><br/>
-	There are a number of tools to ease editing Wikidata.
+	There are a number of tools to ease editing Wikidata,
+	<!--
+
+	    sourcemd is currently disabled.
+	
 	If you want to include a scientific document in Wikidata and it has a DOI, PMID or PMCID identifier
 	then you can use Magnus Manske's <a href="https://tools.wmflabs.org/sourcemd/">sourcemd tool</a>
 	(you need a Wikidata account and authorize Manske's tool to edit in Wikidata).
@@ -24,8 +28,9 @@
 	author has an ORCID profile with public works, 
 	Magnus Manske's sourcemd tool also 
 	efficiently adds papers and authorships to Wikidata. There are a number of other tools, 
+	-->
 	e.g. the <a href="https://tools.wmflabs.org/author-disambiguator/">Author Disambiguator</a> 
-	(by Arthur Smith, based on an initial version by Magnus) 
+	(by Arthur Smith, based on an initial version by Magnus Manske) 
 	that can help identify specific authors based on author name strings.
     </dd>
 


### PR DESCRIPTION
SourceMD is currently disabled so links from Scholia does not work.