### PR TITLE
Fix #793: related events in event aspect

### DIFF
--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -238,7 +238,7 @@ WITH {
         INCLUDE %events 
                 
         # geocoordinate of the query event
-        wd:{{ q }} wdt:P276? / wdt:P625 ?geo0 .
+        wd:{{ q }} wdt:P276? / wdt:P159? / wdt:P625 ?geo0 .
         
         # geocoordinate of other events
         ?event wdt:P276? / wdt:P625 ?geo .


### PR DESCRIPTION
For "Related based on time and location" panel in event aspect results
would not show up if the location did not have a geo-coordinate, but
could be located via the headquarter geo-coordinate.