### PR TITLE
Updated pathway support

### DIFF
--- a/scholia/app/templates/pathway_empty.html
+++ b/scholia/app/templates/pathway_empty.html
@@ -18,12 +18,17 @@
 		<dl>
 		    <dt><a href="Q30225516">Aryl Hydrocarbon Receptor Pathway</a></dt>
 		    <dd>
-			A pathways from WikiPathways.
+			A pathway from WikiPathways.
 		    </dd>
 
 		    <dt><a href="Q30225468">TNF related weak inducer of apoptosis (TWEAK) Signaling Pathway</a></dt>
 		    <dd>
-			A pathways from WikiPathways.
+			A pathway from WikiPathways.
+		    </dd>
+
+		    <dt><a href="Q50294491">Acetyl-CoA + H2O + Oxaloacetate => Citrate + CoA</a></dt>
+		    <dd>
+			A pathway from Reactome.
 		    </dd>
 		</dl>
             </div>

--- a/scholia/app/templates/pathway_empty.html
+++ b/scholia/app/templates/pathway_empty.html
@@ -4,14 +4,92 @@
 
 <h1>Biological pathways</h1>
 
-Biological pathways.
+<div class="container">
 
-<h2>Examples</h2>
+    <h2>Examples</h2>
 
-<ul>
-    <li><a href="Q30225516">Aryl Hydrocarbon Receptor Pathway</a></li>
-    <li><a href="Q30225468">TNF related weak inducer of apoptosis (TWEAK) Signaling Pathway</a></li>
-</ul>
+    <div class="card-deck mb-3">
+	<div class="card mb-4 box-shadow">
+
+            <div class="card-header">
+		<h4 class="my-0 font-weight-normal">Single items</h4>
+            </div>
+            <div class="card-body">
+		<dl>
+		    <dt><a href="Q30225516">Aryl Hydrocarbon Receptor Pathway</a></dt>
+		    <dd>
+			A pathways from WikiPathways.
+		    </dd>
+
+		    <dt><a href="Q30225468">TNF related weak inducer of apoptosis (TWEAK) Signaling Pathway</a></dt>
+		    <dd>
+			A pathways from WikiPathways.
+		    </dd>
+		</dl>
+            </div>
+
+	</div>
+
+
+     <div class="card mb-4 box-shadow">
+	    <div class="card-header">
+		    <h4 class="my-0 font-weight-normal">Redirecting</h4>
+	    </div>
+	    <div class="card-body">
+		<p>If you know the identifier then Scholia can make a lookup based on the identifier:</p>
+
+		<dl>
+		    <dt><a href="../wikipathways/WP111">wikipathways/WP111</a></dt>
+		    <dd>Lookup WikiPathways identifier  WP111, <i>Electron Transport Chain (OXPHOS system in mitochondria)</i></dd>
+		</dl>
+	    </div>
+        </div>
+    </div>
+</div>
+
+<div class="container">
+  <h2>Statistics</h2>
+
+  <table class="table table-hover" id="statistics"></table>
+
+</div>
+
+{% endblock %}
+
+
+{% block scripts %}
+{{super()}}
+
+<script type="text/javascript">
+
+ statisticsSparql = `
+SELECT ?count ?description
+WITH {
+  SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P2410 []. }
+} AS %wikipathways
+WITH {
+  SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P3937 []. }
+} AS %reactome
+WHERE {
+  {
+    INCLUDE %wikipathways
+    BIND("Total number of WikiPathways pathways" AS ?description)
+  }
+  UNION
+  {
+    INCLUDE %reactome
+    BIND("Total number of Reactome pathways" AS ?description)
+  }
+}
+ORDER BY DESC(?count)
+`
+
+ $(document).ready(function() {
+     sparqlToDataTable(statisticsSparql, "#statistics");
+ });
+
+</script>
+
 
 {% endblock %}
 

--- a/scholia/app/templates/pathway_empty.html
+++ b/scholia/app/templates/pathway_empty.html
@@ -65,6 +65,12 @@
  statisticsSparql = `
 SELECT ?count ?description
 WITH {
+  SELECT (COUNT(DISTINCT ?article) AS ?count) WHERE {
+    VALUES ?database { wdt:P2410 wdt:P3937 }
+    [] ?database [] ; wdt:P2860 ?article .
+  }
+} AS %literature
+WITH {
   SELECT (COUNT(*) AS ?count) WHERE { [] wdt:P2410 []. }
 } AS %wikipathways
 WITH {
@@ -74,6 +80,11 @@ WHERE {
   {
     INCLUDE %wikipathways
     BIND("Total number of WikiPathways pathways" AS ?description)
+  }
+  UNION
+  {
+    INCLUDE %literature
+    BIND("Total number of articles cited by pathways" AS ?description)
   }
   UNION
   {

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -16,7 +16,7 @@ from ..query import (arxiv_to_qs, cas_to_qs, doi_to_qs, github_to_qs,
                      inchikey_to_qs, issn_to_qs, orcid_to_qs, viaf_to_qs,
                      q_to_class, random_author, twitter_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,
-                     lipidmaps_to_qs, ror_to_qs)
+                     lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs)
 from ..utils import sanitize_q
 from ..wikipedia import q_to_bibliography_templates
 
@@ -848,6 +848,23 @@ def redirect_pubmed(pmid):
     if len(qs) > 0:
         q = qs[0]
         return redirect(url_for('app.show_work', q=q), code=302)
+    return render_template('404.html')
+
+
+@main.route('/wikipathways/<wpid>')
+def redirect_wikipathways(wpid):
+    """Detect and redirect for WikiPathways identifiers.
+
+    Parameters
+    ----------
+    wpid : str
+        WikiPathways identifier.
+
+    """
+    qs = wikipathways_to_qs(wpid)
+    if len(qs) > 0:
+        q = qs[0]
+        return redirect(url_for('app.show_pathway', q=q), code=302)
     return render_template('404.html')
 
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -21,6 +21,7 @@ Usage:
   scholia.query twitter-to-q <twitter>
   scholia.query viaf-to-q <viaf>
   scholia.query website-to-q <url>
+  scholia.query wikipathways-to-q <wpid>
 
 Examples
 --------
@@ -341,6 +342,39 @@ def ror_to_qs(rorid):
     """
     query = 'select ?work where {{ ?work wdt:P6782 "{rorid}" }}'.format(
         rorid=rorid)
+
+    url = 'https://query.wikidata.org/sparql'
+    params = {'query': query, 'format': 'json'}
+    response = requests.get(url, params=params, headers=HEADERS)
+    data = response.json()
+
+    return [item['work']['value'][31:]
+            for item in data['results']['bindings']]
+
+
+def wikipathways_to_qs(wpid):
+    """Convert a WikiPathways identifier to Wikidata ID.
+
+    Wikidata Query Service is used to resolve the WikiPathways identifier.
+
+    Parameters
+    ----------
+    wpid : str
+        WikiPathways identifier
+
+    Returns
+    -------
+    qs : list of str
+        List of strings with Wikidata IDs.
+
+    Examples
+    --------
+    >>> wikipathways_to_qs('WP111') == ['Q28031254']
+    True
+
+    """
+    query = 'select ?work where {{ VALUES ?wpid {{ "{wpid}" }} ?work wdt:P2410 ?wpid }}'.format(
+        wpid=wpid)
 
     url = 'https://query.wikidata.org/sparql'
     params = {'query': query, 'format': 'json'}
@@ -1161,6 +1195,11 @@ def main():
 
     elif arguments['ror-to-q']:
         qs = ror_to_qs(arguments['<rorid>'])
+        if len(qs) > 0:
+            print(qs[0])
+
+    elif arguments['wikipathways-to-q']:
+        qs = wikipathways_to_qs(arguments['<wpid>'])
         if len(qs) > 0:
             print(qs[0])
 


### PR DESCRIPTION
Adds redirecting for WikiPathways identifiers and a more helpful 'empty' page (early version):

![image](https://user-images.githubusercontent.com/26721/63679167-fb144980-c7f0-11e9-9a6f-a94fefca076f.png)

This supports the work of WikiPathways, which increasingly links to Wikidata, via Scholia.