### PR TITLE
Additional properties and interactive views for pathways

### DIFF
--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -5,14 +5,6 @@
 
 <script type="text/javascript">
     
-    speciesSparql = `
-  SELECT $organism ?organismLabel 
-    WHERE {
-	wd:{{ q }} wdt:P703 ?organism .
-	SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
-    }
-`
-
  participantsSparql = `
 SELECT ?part ?partLabel ?type
 WITH {
@@ -60,7 +52,6 @@ WHERE {
 ORDER BY DESC(?date)
 LIMIT 500
 `
-
   citingArticlesSparql = `
 #defaultView:Table
 SELECT ?citations ?publication_date ?citing_work ?citing_workLabel
@@ -83,7 +74,7 @@ WHERE {
 ORDER BY DESC(?citations) DESC(?date)
 `
 
-const wikipathwaysSparql = `SELECT ?wpid ?organism
+const wikipathwaysSparql = `SELECT ?wpid ?organism ?organismLabel
 WHERE {
 	wd:{{ q }} wdt:P2410 ?wpid .
 	wd:{{ q }} wdt:P703 ?organism .
@@ -93,7 +84,6 @@ const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/
 	encodeURIComponent(wikipathwaysSparql) + '&format=json';
 
  $(document).ready(function() {
-   sparqlToDataTable(speciesSparql, "#species");
    sparqlToDataTable(participantsSparql, "#participants");
    sparqlToDataTable(recentArticlesSparql, "#recentArticles");
    sparqlToDataTable(citingArticlesSparql, "#citingArticles");
@@ -102,6 +92,7 @@ const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/
    $.getJSON(wikipathwaysSparqlURL, function(response) {
 	   const simpleData = sparqlDataToSimpleData(response);
 	   const wikipathwaysData = simpleData.data[0];
+	   $("#Organism").after('<a href="'+wikipathwaysData["organism"]+'">'+wikipathwaysData["organismLabel"]+'</a>');
 	   if ("wpid" in wikipathwaysData) {
 		const wpid = wikipathwaysData.wpid;
 	   	const pathwayViewerIFrameResults = $.find("#pathway-viewer > iframe");
@@ -127,9 +118,7 @@ const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/
   <iframe class="embed-responsive-item" src="" style="border-width: 1px; border-color: rgb(222,226,230); border-style: solid;" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
 </div>
 
-<h2 id="Species"> Species </h2>
-
-<table class="table table-hover" id="species"></table>
+<h2 id="Organism"> Organism </h2>
 
 <h2 id="Participants">Participants</h2>
 

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -124,7 +124,7 @@ const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/
 <div id="intro"></div>
 
 <div id="pathway-viewer" class="embed-responsive embed-responsive-16by9">
-  <iframe class="embed-responsive-item" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
+  <iframe class="embed-responsive-item" src="" style="border-width: 1px; border-color: rgb(222,226,230); border-style: solid;" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
 </div>
 
 <h2 id="Species"> Species </h2>

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -5,7 +5,7 @@
 
 <script type="text/javascript">
     
- participantsSparql = `
+const participantsSparql = `
 SELECT ?part ?partLabel ?type
 WITH {
   SELECT ?part (GROUP_CONCAT(DISTINCT ?type_label; separator=", ") AS ?type)
@@ -21,7 +21,7 @@ WHERE {
 } ORDER BY ASC(?partLabel)
 `
 
-  recentArticlesSparql = `
+const recentArticlesSparql = `
 SELECT ?date ?work ?workLabel ?type ?topics
 WITH {
   SELECT DISTINCT ?work WHERE {
@@ -52,7 +52,8 @@ WHERE {
 ORDER BY DESC(?date)
 LIMIT 500
 `
-  citingArticlesSparql = `
+
+const citingArticlesSparql = `
 #defaultView:Table
 SELECT ?citations ?publication_date ?citing_work ?citing_workLabel
 WITH {
@@ -92,7 +93,7 @@ const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/
    $.getJSON(wikipathwaysSparqlURL, function(response) {
 	   const simpleData = sparqlDataToSimpleData(response);
 	   const wikipathwaysData = simpleData.data[0];
-	   $("#Organism").after('<a href="'+wikipathwaysData["organism"]+'">'+wikipathwaysData["organismLabel"]+'</a>');
+	   $("#Organism").after('<a href="'+wikipathwaysData.organism+'">'+wikipathwaysData.organismLabel+'</a>');
 	   if ("wpid" in wikipathwaysData) {
 		const wpid = wikipathwaysData.wpid;
 	   	const pathwayViewerIFrameResults = $.find("#pathway-viewer > iframe");

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -4,6 +4,14 @@
 {{super()}}
 
 <script type="text/javascript">
+    
+    speciesSparql = `
+  SELECT $organism ?organismLabel 
+    WHERE {
+	wd:{{ q }} wdt:P703 ?organism .
+	SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+    }
+`
 
  participantsSparql = `
 SELECT ?part ?partLabel ?type
@@ -85,6 +93,7 @@ const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/
 	encodeURIComponent(wikipathwaysSparql) + '&format=json';
 
  $(document).ready(function() {
+   sparqlToDataTable(speciesSparql, "#species");
    sparqlToDataTable(participantsSparql, "#participants");
    sparqlToDataTable(recentArticlesSparql, "#recentArticles");
    sparqlToDataTable(citingArticlesSparql, "#citingArticles");
@@ -118,6 +127,9 @@ const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/
   <iframe class="embed-responsive-item" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
 </div>
 
+<h2 id="Species"> Species </h2>
+
+<table class="table table-hover" id="species"></table>
 
 <h2 id="Participants">Participants</h2>
 

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -75,35 +75,47 @@ WHERE {
 ORDER BY DESC(?citations) DESC(?date)
 `
 
-const wikipathwaysSparql = `SELECT ?wpid ?organism ?organismLabel
+//Extensible query for muliple, optional values
+const optionalDataValuesSparql =`
+SELECT ?wpid ?organism ?organismLabel
 WHERE {
-	wd:{{ q }} wdt:P2410 ?wpid .
-	wd:{{ q }} wdt:P703 ?organism .
-	SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
-}`
-const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/sparql?query=" + 
-	encodeURIComponent(wikipathwaysSparql) + '&format=json';
+  OPTIONAL { wd:{{ q }} wdt:P2410 ?wpid . }
+  OPTIONAL { wd:{{ q }} wdt:P703 ?organism . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+}
+`
 
- $(document).ready(function() {
-   sparqlToDataTable(participantsSparql, "#participants");
-   sparqlToDataTable(recentArticlesSparql, "#recentArticles");
-   sparqlToDataTable(citingArticlesSparql, "#citingArticles");
-   var pathwayViewerSection = document.getElementById("pathway-viewer")
-   pathwayViewerSection.style.display = "none"
-   $.getJSON(wikipathwaysSparqlURL, function(response) {
-	   const simpleData = sparqlDataToSimpleData(response);
-	   const wikipathwaysData = simpleData.data[0];
-	   $("#Organism").after('<a href="'+wikipathwaysData.organism+'">'+wikipathwaysData.organismLabel+'</a>');
-	   if ("wpid" in wikipathwaysData) {
-		const wpid = wikipathwaysData.wpid;
-	   	const pathwayViewerIFrameResults = $.find("#pathway-viewer > iframe");
-		pathwayViewerIFrameResults.every(function(pathwayViewerIFrameResult) {
-			pathwayViewerIFrameResult.setAttribute("src", `https://tools.wmflabs.org/pathway-viewer/?id=${wpid}`);
-		});
-	  	pathwayViewerSection.style.display = "";
-	  }
-   });
- });
+$(document).ready(function() {
+  sparqlToDataTable(participantsSparql, "#participants");
+  sparqlToDataTable(recentArticlesSparql, "#recentArticles");
+  sparqlToDataTable(citingArticlesSparql, "#citingArticles");
+
+  //Hide optional sections until data values are confirmed and ready
+  var organismSection = document.getElementById("Organism")                                                                                         
+  organismSection.style.display = "none"; 
+  var pathwayViewerSection = document.getElementById("pathway-viewer")                                                                                
+  pathwayViewerSection.style.display = "none"; 
+
+  //Check for optional data values and then use them if available
+  const sparqlURL = 'https://query.wikidata.org/bigdata/namespace/wdq/sparql?query=' + 
+        encodeURIComponent(optionalDataValuesSparql) + '&format=json';
+  $.getJSON(sparqlURL, function(response) {
+    const simpleData = sparqlDataToSimpleData(response);
+    const dataValues = simpleData.data[0];
+    if ("organism" in dataValues) {
+      $("#Organism").after('<a href="'+dataValues.organism+'">'+dataValues.organismLabel+'</a>'); 
+      organismSection.style.display = "";
+    }
+    if ("wpid" in dataValues) {
+      const pathwayViewerIFrameResults = $.find("#pathway-viewer > iframe");
+      pathwayViewerIFrameResults.every(function(pathwayViewerIFrameResult) {
+        pathwayViewerIFrameResult.setAttribute("src", `https://tools.wmflabs.org/pathway-viewer/?id=${dataValues.wpid}`);
+      });
+      pathwayViewerSection.style.display = "";
+    }
+  });
+});
+
 </script>
 
 {% endblock %}

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -75,10 +75,33 @@ WHERE {
 ORDER BY DESC(?citations) DESC(?date)
 `
 
+const wikipathwaysSparql = `SELECT ?wpid ?organism
+WHERE {
+	wd:{{ q }} wdt:P2410 ?wpid .
+	wd:{{ q }} wdt:P703 ?organism .
+	SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+}`
+const wikipathwaysSparqlURL = "https://query.wikidata.org/bigdata/namespace/wdq/sparql?query=" + 
+	encodeURIComponent(wikipathwaysSparql) + '&format=json';
+
  $(document).ready(function() {
    sparqlToDataTable(participantsSparql, "#participants");
    sparqlToDataTable(recentArticlesSparql, "#recentArticles");
    sparqlToDataTable(citingArticlesSparql, "#citingArticles");
+   var pathwayViewerSection = document.getElementById("pathway-viewer")
+   pathwayViewerSection.style.display = "none"
+   $.getJSON(wikipathwaysSparqlURL, function(response) {
+	   const simpleData = sparqlDataToSimpleData(response);
+	   const wikipathwaysData = simpleData.data[0];
+	   if ("wpid" in wikipathwaysData) {
+		const wpid = wikipathwaysData.wpid;
+	   	const pathwayViewerIFrameResults = $.find("#pathway-viewer > iframe");
+		pathwayViewerIFrameResults.every(function(pathwayViewerIFrameResult) {
+			pathwayViewerIFrameResult.setAttribute("src", `https://tools.wmflabs.org/pathway-viewer/?id=${wpid}`);
+		});
+	  	pathwayViewerSection.style.display = "";
+	  }
+   });
  });
 </script>
 
@@ -90,6 +113,11 @@ ORDER BY DESC(?citations) DESC(?date)
 <h1 id="h1">Pathway</h1>
 
 <div id="intro"></div>
+
+<div id="pathway-viewer" class="embed-responsive embed-responsive-16by9">
+  <iframe class="embed-responsive-item" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
+</div>
+
 
 <h2 id="Participants">Participants</h2>
 


### PR DESCRIPTION
- Introduces two new sections: An interactive pathway viewer iframe and a link to organism
- Utilizes a new generic sparql query that is extensible for future uses
- Fails gracefully by hiding sections if data is not available
- Adds `const` per convention

Please let us know if we can improve upon this PR in any way. We are eager to contribute to scholia for pathway views.