### PR TITLE
Support UTF8 in TeX output

### DIFF
--- a/scholia/tex.py
+++ b/scholia/tex.py
@@ -100,8 +100,10 @@ STRING_TO_TEX_URL_PATTERN = re.compile(
     flags=re.UNICODE)
 
 COMBINING_DIACRITIC_TO_TEX_PATTERN = re.compile(
-    u'(.)({})'.format(u'|'.join(re.escape(key) for key in COMBINING_DIACRITIC_TO_TEX)),
+    u'(.)({})'.format(
+        u'|'.join(re.escape(key)for key in COMBINING_DIACRITIC_TO_TEX)),
     flags=re.UNICODE)
+
 
 def escape_to_tex(string, escape_type='normal'):
     r"""Escape a text to the a tex/latex safe.
@@ -109,7 +111,7 @@ def escape_to_tex(string, escape_type='normal'):
     Parameters
     ----------
     string : str or None
-        Unicode string to be excaped.
+        Unicode string to be escaped.
     escape_type : normal or url, default normal
         Type of escaping.
 
@@ -149,9 +151,9 @@ def escape_to_tex(string, escape_type='normal'):
         lambda match: '{{{} {}}}'.format(
             COMBINING_DIACRITIC_TO_TEX[match.group(2)],
             match.group(1)),
-        unicodedata.normalize('NFD', escaped_string))
-
+        unicodedata.normalize('NFD', u(escaped_string)))
     return escaped_string
+
 
 def guess_bibtex_entry_type(entity):
     """Guess Bibtex entry type.


### PR DESCRIPTION
  - [x] accents
  - [ ] other symbols
  - [ ] tests

  1. One thing I found a bit confusing is that even with the accent conversion working (i.e., the BibTeX output contains just `{\. s}`, pdfLaTeX on Overleaf still complains about an unknown Unicode character, *with* `\usepackage[utf8]{inputenc}`.
  2. I'm not really familiar with Unicode strings in Python 2.7 yet, so there may be some problems there.
  3. For other symbols, there's [a great, big list](https://www.rpi.edu/dept/arc/training/latex/LaTeX_symbols.pdf) and I don't really know if we want to include all of that.

See #61