### PR TITLE
Fix #818 renaming "Pubs" to "Works"

### DIFF
--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -7,7 +7,7 @@
 <script type="text/javascript">
  peopleSparql = `
 SELECT
-  (?number_of_publications AS ?pubs)
+  (?number_of_publications AS ?works)
   ?person ?personLabel ?personDescription
   ?roles
   ?example_work ?example_workLabel


### PR DESCRIPTION
The first table in the event aspect showed the word "pubs" as
a short form of publications. "Works" might be more understandable.