### PR TITLE
Add events attended/participated/organized to author aspect

### DIFF
--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -138,9 +138,9 @@ ORDER BY DESC(?count)
  conferencesSparql = `
 #defaultView:Table
 SELECT
+  (year(?start) as ?year)  
   ?conference
   ?conferenceLabel
-  (year(?start) as ?year)
   # ?hashtag
   # (GROUP_CONCAT(DISTINCT ?shortName; separator=", ") AS ?shortNames)
   (GROUP_CONCAT(DISTINCT ?role; separator=", ") AS ?roles)

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -138,7 +138,7 @@ ORDER BY DESC(?count)
  conferencesSparql = `
 #defaultView:Table
 SELECT
-  (year(?start) as ?year)  
+  (YEAR(?start) AS ?year)  
   ?conference
   ?conferenceLabel
   # ?hashtag

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -32,7 +32,7 @@ WHERE {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh". }  
 }
 GROUP BY ?work ?workLabel ?venue ?venueLabel
-ORDER BY DESC(?date)    
+ORDER BY DESC(?year)    
  `
 
  venueStatisticsSparql = `
@@ -173,6 +173,7 @@ WHERE {
     SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 GROUP BY ?conference ?conferenceLabel ?start
+ORDER BY DESC(?start) 
 `;
  
  function resize() {

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -173,7 +173,7 @@ WHERE {
     SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
 GROUP BY ?conference ?conferenceLabel ?start
-ORDER BY DESC(?start) 
+ORDER BY DESC(?year) 
 `;
  
  function resize() {

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -135,12 +135,12 @@ WHERE {
 ORDER BY DESC(?count)
 `
 
- conferencesSparql = `
+ eventsSparql = `
 #defaultView:Table
 SELECT
   (YEAR(?start) AS ?year)  
-  ?conference
-  ?conferenceLabel
+  ?event
+  ?eventLabel
   # ?hashtag
   # (GROUP_CONCAT(DISTINCT ?shortName; separator=", ") AS ?shortNames)
   (GROUP_CONCAT(DISTINCT ?role; separator=", ") AS ?roles)
@@ -148,31 +148,31 @@ SELECT
 WHERE {
     BIND(wd:{{ q }} as ?person)
     {  # speaker
-      ?conference wdt:P823 ?person .
+      ?event wdt:P823 ?person .
       BIND("speaker" AS ?role)
     } UNION {  # organizer
-      ?conference wdt:P664 ?person .
+      ?event wdt:P664 ?person .
       BIND("organizer" AS ?role)
     } UNION {  # participant
-      ?person wdt:P1344 | ^wdt:P710 ?conference  .
+      ?person wdt:P1344 | ^wdt:P710 ?event  .
       BIND("participant" AS ?role)
     } UNION {  # editor
-      ?person ^wdt:P98 / wdt:P4745 ?conference  .
+      ?person ^wdt:P98 / wdt:P4745 ?event  .
       BIND("editor of proceedings" AS ?role)
     } UNION {  # author
-      ?person ^wdt:P50 / wdt:P1433 / wdt:P4745 ?conference  .
+      ?person ^wdt:P50 / wdt:P1433 / wdt:P4745 ?event  .
       BIND("author" AS ?role)
     } UNION {  # program committee member
-      ?conference wdt:P5804 ?person .
+      ?event wdt:P5804 ?person .
       BIND("program committee member" AS ?role)
     }
-    OPTIONAL { ?conference wdt:P276 ?location . ?location rdfs:label ?location_label . FILTER (LANG(?location_label) = 'en')}
-    OPTIONAL { ?conference wdt:P580 ?start }
-    # OPTIONAL { ?conference wdt:P2572 ?hashtag }
-    # OPTIONAL { ?conference wdt:P1813 ?shortName }
+    OPTIONAL { ?event wdt:P276 ?location . ?location rdfs:label ?location_label . FILTER (LANG(?location_label) = 'en')}
+    OPTIONAL { ?event wdt:P580 ?start }
+    # OPTIONAL { ?event wdt:P2572 ?hashtag }
+    # OPTIONAL { ?event wdt:P1813 ?shortName }
     SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh". }
 }
-GROUP BY ?conference ?conferenceLabel ?start
+GROUP BY ?event ?eventLabel ?start
 ORDER BY DESC(?year) 
 `;
  
@@ -200,7 +200,7 @@ ORDER BY DESC(?year)
      sparqlToDataTable(topicsSparql, "#topics");
      sparqlToDataTable(mostCitedWorksSparql, "#most-cited-works");
      sparqlToDataTable(citingAuthorsSparql, "#citing-authors");
-     sparqlToDataTable(conferencesSparql, "#conferences");
+     sparqlToDataTable(eventsSparql, "#events");
 
      window.onresize = resize;
 
@@ -535,6 +535,6 @@ Are citing authors missing here? You can help curate them via the <a href="{{ ur
 
 Events the author has attended, organized, or in which they have participated in other ways.
 
-<table class="table table-hover table-striped" id="conferences"></table>
+<table class="table table-hover table-striped" id="events"></table>
 
 {% endblock %}

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -32,7 +32,7 @@ WHERE {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh". }  
 }
 GROUP BY ?work ?workLabel ?venue ?venueLabel
-ORDER BY DESC(?year)    
+ORDER BY DESC(?date)  
  `
 
  venueStatisticsSparql = `

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -531,9 +531,9 @@ Authors that cite the author (excluding self citations).
 Are citing authors missing here? You can help curate them via the <a href="{{ url_for('app.show_author_empty') }}{{ q }}/missing">missing</a> page.
 
 
-<h2>Conferences Attended</h2>
+<h2>Events</h2>
 
-Conferences the author has attended.
+Events the author has attended, organized, or in which they have participated in other ways.
 
 <table class="table table-hover table-striped" id="conferences"></table>
 

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -134,6 +134,46 @@ WHERE {
 } 
 ORDER BY DESC(?count)
 `
+
+ conferencesSparql = `
+#defaultView:Table
+SELECT
+  ?conference
+  ?conferenceLabel
+  (year(?start) as ?year)
+  # ?hashtag
+  # (GROUP_CONCAT(DISTINCT ?shortName; separator=", ") AS ?shortNames)
+  (GROUP_CONCAT(DISTINCT ?role; separator=", ") AS ?roles)
+  (GROUP_CONCAT(DISTINCT ?location_label; separator=", ") AS ?locations)
+WHERE {
+    BIND(wd:{{ q }} as ?person)
+    {  # speaker
+      ?conference wdt:P823 ?person .
+      BIND("speaker" AS ?role)
+    } UNION {  # organizer
+      ?conference wdt:P664 ?person .
+      BIND("organizer" AS ?role)
+    } UNION {  # participant
+      ?person wdt:P1344 | ^wdt:P710 ?conference  .
+      BIND("participant" AS ?role)
+    } UNION {  # editor
+      ?person ^wdt:P98 / wdt:P4745 ?conference  .
+      BIND("editor of proceedings" AS ?role)
+    } UNION {  # author
+      ?person ^wdt:P50 / wdt:P1433 / wdt:P4745 ?conference  .
+      BIND("author" AS ?role)
+    } UNION {  # program committee member
+      ?conference wdt:P5804 ?person .
+      BIND("program committee member" AS ?role)
+    }
+    OPTIONAL { ?conference wdt:P276 ?location . ?location rdfs:label ?location_label . FILTER (LANG(?location_label) = 'en')}
+    OPTIONAL { ?conference wdt:P580 ?start }
+    # OPTIONAL { ?conference wdt:P2572 ?hashtag }
+    # OPTIONAL { ?conference wdt:P1813 ?shortName }
+    SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,no,ru,sv,zh". }
+}
+GROUP BY ?conference ?conferenceLabel ?start
+`;
  
  function resize() {
      width = document.getElementById("topics-works-matrix").clientWidth;
@@ -159,6 +199,7 @@ ORDER BY DESC(?count)
      sparqlToDataTable(topicsSparql, "#topics");
      sparqlToDataTable(mostCitedWorksSparql, "#most-cited-works");
      sparqlToDataTable(citingAuthorsSparql, "#citing-authors");
+     sparqlToDataTable(conferencesSparql, "#conferences");
 
      window.onresize = resize;
 
@@ -489,6 +530,10 @@ Authors that cite the author (excluding self citations).
 Are citing authors missing here? You can help curate them via the <a href="{{ url_for('app.show_author_empty') }}{{ q }}/missing">missing</a> page.
 
 
+<h2>Conferences Attended</h2>
 
+Conferences the author has attended.
+
+<table class="table table-hover table-striped" id="conferences"></table>
 
 {% endblock %}


### PR DESCRIPTION
Closes #849

I've made a SPARQL query that queries the conference, its year, the authors' roles, and the locations. It now is displayed as a table in the author aspect. It gets added to a table using `sparqlToDataTable`.

There are some comments for extensions to the SPARQL query the conference's short names and hashtag, in case you think that might also be interesting.

Two differences from the other parts of this aspect:

- I used `BIND` in SPARQL rather than using `{{ q }}` several times
- The table has the `table-striped` class. If you disagree with this, then I can remove it :)

I tested locally with http://localhost:8100/author/Q20895241 and got:

<img width="1151" alt="Screenshot 2019-10-15 22 27 41" src="https://user-images.githubusercontent.com/5069736/66867171-04bd6080-ef9b-11e9-97b7-e61ce122ba89.png">

