### PR TITLE
Adds a chemistry/missing page for curation

### DIFF
--- a/scholia/app/templates/chemical_empty.html
+++ b/scholia/app/templates/chemical_empty.html
@@ -58,6 +58,23 @@ Chemical substances.
 	    </div>
         </div>
     </div>
+
+     <div class="card mb-4 box-shadow">
+	    <div class="card-header">
+		    <h4 class="my-0 font-weight-normal">ChemCuration</h4>
+	    </div>
+	    <div class="card-body">
+		<p>There is always more information about chemicals that can be added. This section
+		   adds some useful resource for chemistry curation:</p>
+
+		<dl>
+		    <dt><a href="https://www.wikidata.org/wiki/Wikidata:Database_reports/Constraint_violations/P662">PubChem CID violations</a></dt>
+		    <dd>This page shows CIDs linked to more than one Wikidata item (a "Unique value" violation) and
+		        Wikidata items with more than one CID ("Single value" violations).</dd>
+		</dl>
+	    </div>
+        </div>
+    </div>
 </div>
 
 <div class="container">

--- a/scholia/app/templates/chemical_empty.html
+++ b/scholia/app/templates/chemical_empty.html
@@ -71,6 +71,11 @@ Chemical substances.
 		    <dd>This page shows CIDs linked to more than one Wikidata item (a "Unique value" violation) and
 		        Wikidata items with more than one CID ("Single value" violations).</dd>
 		</dl>
+
+		<dl>
+		    <dt><a href="./missing">Missing physicochemical properties</a></dt>
+		    <dd>This page shows lists of compounds with missing properties, like boiling points.</dd>
+		</dl>
 	    </div>
         </div>
     </div>

--- a/scholia/app/templates/chemical_empty.html
+++ b/scholia/app/templates/chemical_empty.html
@@ -56,7 +56,6 @@ Chemical substances.
 		    <dd>And for LIPID MAPS identifiers</dd>
 		</dl>
 	    </div>
-        </div>
     </div>
 
      <div class="card mb-4 box-shadow">

--- a/scholia/app/templates/chemical_empty.html
+++ b/scholia/app/templates/chemical_empty.html
@@ -19,6 +19,11 @@ Chemical substances.
             </div>
             <div class="card-body">
 		<dl>
+		    <dt><a href="Q18216">aspirin</a></dt>
+		    <dd>
+			View information about the painkiller aspirin.
+		    </dd>
+
 		    <dt><a href="Q2270">benzene</a></dt>
 		    <dd>
 			View information about the chemical benzene.
@@ -27,6 +32,16 @@ Chemical substances.
 		    <dt><a href="Q159683">citric acid</a></dt>
 		    <dd>
 			View information about the chemical citric acid.
+		    </dd>
+
+		    <dt><a href="Q20035886">L-proline</a></dt>
+		    <dd>
+			View information about the natural amino acid L-proline
+		    </dd>
+
+		    <dt><a href="Q23118">LSD</a></dt>
+		    <dd>
+			View information about the drug LSD.
 		    </dd>
 		</dl>
             </div>

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -9,7 +9,8 @@
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2102 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -24,7 +25,8 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2101 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -39,7 +41,8 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 30)
     FILTER(NOT EXISTS {?compound wdt:P2067 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -54,7 +57,8 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2177 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -69,7 +73,8 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P3078 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -84,7 +89,8 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2119 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -99,7 +105,8 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P3071 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -114,7 +121,8 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2054 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -128,7 +136,8 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P117 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -143,7 +152,8 @@ missingFlashPointSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2128 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -158,7 +168,8 @@ missingpKaSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P1117 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -173,7 +184,8 @@ missingCombustionEnthalpy = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2117 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100
@@ -188,7 +200,8 @@ missingIDLH = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
   SELECT ?wikis ?compound WHERE {
     ?compound wdt:P31 wd:Q11173 ;
-              wikibase:sitelinks ?wikis .
+              wikibase:sitelinks ?wikis . hint:Prior hint:rangeSafe true .
+    FILTER(?wikis >= 40)
     FILTER(NOT EXISTS {?compound wdt:P2129 []})
   } ORDER BY DESC(?wikis)
   LIMIT 100

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -194,7 +194,7 @@ $(document).ready(function() {
      sparqlToDataTable(missingEnthalpyOfFormationSparql, "#missing-enthalpy-of-formation");
      sparqlToDataTable(missingVaporPressureSparql, "#missing-vapor-pressure");
      sparqlToDataTable(missingStandardMolarEnthropySparql, "#missing-molar-enthropy");
-     sparqlToDataTable(missingDensitySparql, "#missing-density");     
+     sparqlToDataTable(missingDensitySparql, "#missing-density");
      sparqlToDataTable(missingChemicalStructureSparql, "#missing-chemical-structure");
      sparqlToDataTable(missingFlashPointSparql, "#missing-flash-point");
      sparqlToDataTable(missingpKaSparql, "#missing-pKa");
@@ -202,11 +202,8 @@ $(document).ready(function() {
      sparqlToDataTable(missingIDLH, "#missing-idlh");
  });
 </script>
-
- 
  
 {% endblock %}
-
 
 {% block page_content %}
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -220,7 +220,7 @@ $(document).ready(function() {
 
 {% block page_content %}
 
-<h1>Missing physicalchemical properties for chemicals</h1>
+<h1>Missing physicochemical properties for chemicals</h1>
 
 When adding missing physicochemical properties, please take the following into account:
 
@@ -240,7 +240,7 @@ at which boiling occurs under a pressure of one bar.
 Typical units given include degrees
 <a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degree
 <a href="{{ url_for('app.show_topic_empty') }}Q25267">Celsius</a>. Because it
-is depends on the pressure, this is often also given, as shown in
+it depends on the pressure, this is often also given, as shown in
 <a href="https://www.wikidata.org/wiki/Property:P2102#P1855">these examples</a>.
 
 <table class="table table-hover" id="missing-boiling-points"></table>

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -222,6 +222,17 @@ $(document).ready(function() {
 
 <h1>Missing physicalchemical properties for chemicals</h1>
 
+When adding missing physicochemical properties, please take the following into account:
+
+<ul>
+  <li>use units: <a href="https://www.wikidata.org/wiki/Wikidata:Units">Wikidata:Units</a></li>
+  <li>use references: <a href="https://www.wikidata.org/wiki/Help:Sources">Help:Sources</a></li>
+</ul>
+
+The following links prioritize chemical compounds that are listed in most Wikis
+(Wikipedias, WikiCommons, etc). To go to the Wikidata page for each item, click the name
+below and then on the shown Scholia page for that compound the Q-identifier link at the top.
+
 <h2 id="h1">Missing Boiling Points</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2102">boiling point</a> is the temperature above

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -6,12 +6,17 @@
 
   <script type="text/javascript">
     missingBoilingPointsSparql = `
-SELECT ?compound ?compoundLabel WHERE
-{
-  ?compound wdt:P31 wd:Q11173.
-  FILTER(NOT EXISTS {?compound wdt:P2102 []})
+SELECT ?compound ?compoundLabel WITH {
+  SELECT ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173.
+    FILTER(NOT EXISTS {?compound wdt:P2102 []})
+  }
+  LIMIT 500
+} AS %CHEMICALS WHERE {
+  INCLUDE %CHEMICALS
+  OPTIONAL { ?compound wdt:P274 ?formula }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 }
-LIMIT 500
 `
 
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -7,11 +7,11 @@
   <script type="text/javascript">
     missingBoilingPointsSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2102 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -22,11 +22,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
  missingMeltingPointsSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2101 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -37,11 +37,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
   missingMassSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2067 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -52,11 +52,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
   missingSolubilitySparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2177 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -67,11 +67,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
   missingEnthalpyOfFormationSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P3078 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -82,11 +82,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
   missingVaporPressureSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2119 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -97,11 +97,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
   missingStandardMolarEntropySparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P3071 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -112,11 +112,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
   missingDensitySparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2054 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -126,11 +126,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 `
   missingChemicalStructureSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P117 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -141,11 +141,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
 missingFlashPointSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2128 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -156,11 +156,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
 missingpKaSparql = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P1117 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -171,11 +171,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
 missingCombustionEnthalpy = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2117 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
@@ -186,11 +186,11 @@ SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
 
 missingIDLH = `
 SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
-  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
+  SELECT ?wikis ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173 ;
+              wikibase:sitelinks ?wikis .
     FILTER(NOT EXISTS {?compound wdt:P2129 []})
-    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
-  } GROUP BY ?compound ORDER BY DESC(?wikis)
+  } ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -224,9 +224,19 @@ $(document).ready(function() {
 
 <h2 id="h1">Missing Boiling Points</h2>
 
+The <a href="https://www.wikidata.org/wiki/Property:P2102">boiling point</a> is the temperature above
+which the compound is liquid. Typical units given include Kelvin and degree Celsius. Because it
+is depends on the pressure, this is often also given, as shown in
+<a href="https://www.wikidata.org/wiki/Property:P2102#P1855">these examples</a>.
+
 <table class="table table-hover" id="missing-boiling-points"></table>
 
 <h2 id="h1">Missing Melting Points</h2>
+
+The <a href="https://www.wikidata.org/wiki/Property:P2101">melting point</a> is the temperature above
+which the compound is fluid. Typical units given include Kelvin and degree Celsius. It is
+often found for organic chemicals as part of their unique characterization. Check out
+<a href="https://www.wikidata.org/wiki/Property:P2101#P1855">these examples</a>.
 
 <table class="table table-hover" id="missing-melting-points"></table>
 
@@ -236,9 +246,17 @@ $(document).ready(function() {
 
 <h2 id="h1">Missing Solubility</h2>
 
+The <a href="https://www.wikidata.org/wiki/Property:P2177">solubility</a>
+of a compound is always in some solvent and depending on the temperature. The
+latter two are therefore commonly given as qualifiers, as for this
+<a href="https://www.wikidata.org/wiki/Property:P2177#P1855">example</a>.
+
 <table class="table table-hover" id="missing-solubility"></table>
 
 <h2 id="h1">Missing Enthalpy Of Formation</h2>
+
+The <a href="https://www.wikidata.org/wiki/Property:P3078">enthalpy of formation</a>
+is a measure of the stability of the compound.
 
 <table class="table table-hover" id="missing-enthalpy-of-formation"></table>
 
@@ -271,6 +289,9 @@ $(document).ready(function() {
 <table class="table table-hover" id="missing-combustion-enthalpy"></table>
 
 <h2 id="h1">Missing IDLH</h2>
+
+The <a href="https://www.wikidata.org/wiki/Property:P2129">Immediately Dangerous to Life and Health value</a>
+(IDLH) is an indication provided by the U.S.A. CDC about the danger of the compound.
 
 <table class="table table-hover" id="missing-idlh"></table>
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -130,20 +130,6 @@ SELECT ?compound ?compoundLabel ?formula WITH {
 }
 `
 
-  missingHasPartSparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
-    ?compound wdt:P31 wd:Q11173.
-    FILTER(NOT EXISTS {?compound wdt:P527 []})
-  }
-  LIMIT 100
-} AS %CHEMICALS WHERE {
-  INCLUDE %CHEMICALS
-  OPTIONAL { ?compound wdt:P274 ?formula }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
-`
-
 missingFlashPointSparql = `
   SELECT ?compound ?compoundLabel ?formula WITH {
   SELECT ?compound WHERE {
@@ -210,7 +196,6 @@ $(document).ready(function() {
      sparqlToDataTable(missingStandardMolarEnthropySparql, "#missing-molar-enthropy");
      sparqlToDataTable(missingDensitySparql, "#missing-density");     
      sparqlToDataTable(missingChemicalStructureSparql, "#missing-chemical-structure");
-     sparqlToDataTable(missingHasPartSparql, "#missing-has-part");
      sparqlToDataTable(missingFlashPointSparql, "#missing-flash-point");
      sparqlToDataTable(missingpKaSparql, "#missing-pKa");
      sparqlToDataTable(missingCombustionEnthalpy, "#missing-combustion-enthalpy");
@@ -260,10 +245,6 @@ $(document).ready(function() {
 <h1 id="h1">Missing Chemical Structure</h1>
 
 <table class="table table-hover" id="missing-chemical-structure"></table>
-
-<h1 id="h1">Missing Has Part</h1>
-
-<table class="table table-hover" id="missing-has-part"></table>
 
 <h1 id="h1">Missing Flash Point</h1>
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -243,16 +243,16 @@ When adding missing physicochemical properties, please take the following into a
 </ul>
 
 The following links prioritize chemical compounds that are listed in most Wikis
-(Wikipedias, WikiCommons, etc). To go to the Wikidata page for each item, click the name
-below and then on the shown Scholia page for that compound the Q-identifier link at the top.
+(Wikipedias, Wikimedia Commons, etc). To go to the Wikidata page for each item, click its name
+below, which will lead to its Scholia page which links to the Wikidata page via the <a href="https://www.wikidata.org/wiki/Wikidata:Glossary">Q number</a> link at the top.
 
 <h2 id="h1">Missing Boiling Points</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2102">boiling point</a> is the temperature
 at which boiling occurs under a pressure of one bar.
 Typical units given include degrees
-<a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degree
-<a href="{{ url_for('app.show_topic_empty') }}Q25267">Celsius</a>. Because it
+<a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degrees
+<a href="{{ url_for('app.show_topic_empty') }}Q25267">Celsius</a>. Because 
 it depends on the pressure, this is often also given, as shown in
 <a href="https://www.wikidata.org/wiki/Property:P2102#P1855">these examples</a>.
 
@@ -261,7 +261,7 @@ it depends on the pressure, this is often also given, as shown in
 <h2 id="h1">Missing Melting Points</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2101">melting point</a> is the temperature at which a compound melts. Typical units given include degrees
-<a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degree
+<a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degrees
 <a href="{{ url_for('app.show_topic_empty') }}Q25267">Celsius</a>. It is
 often found for organic chemicals as part of their unique characterization. Check out
 <a href="https://www.wikidata.org/wiki/Property:P2101#P1855">these examples</a>.
@@ -281,7 +281,7 @@ latter two are therefore commonly given as qualifiers, as for this
 
 <table class="table table-hover" id="missing-solubility"></table>
 
-<h2 id="h1">Missing Enthalpy Of Formation</h2>
+<h2 id="h1">Missing Enthalpy of Formation</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P3078">enthalpy of formation</a>
 is a measure of the stability of the compound.
@@ -319,7 +319,7 @@ is a measure of the stability of the compound.
 <h2 id="h1">Missing IDLH</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2129">Immediately Dangerous to Life and Health value</a>
-(IDLH) is an indication provided by the U.S.A. <a href="{{ url_for('app.show_topic_empty') }}Q583725">CDC</a> about the danger of the compound.
+(IDLH) is an indication provided by the U.S. <a href="{{ url_for('app.show_organization_empty') }}Q583725">CDC</a> about the danger of the compound.
 
 <table class="table table-hover" id="missing-idlh"></table>
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -235,8 +235,11 @@ below and then on the shown Scholia page for that compound the Q-identifier link
 
 <h2 id="h1">Missing Boiling Points</h2>
 
-The <a href="https://www.wikidata.org/wiki/Property:P2102">boiling point</a> is the temperature above
-which the compound is liquid. Typical units given include Kelvin and degree Celsius. Because it
+The <a href="https://www.wikidata.org/wiki/Property:P2102">boiling point</a> is the temperature
+at which boiling occurs under a pressure of one bar.
+Typical units given include degrees
+<a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degree
+<a href="{{ url_for('app.show_topic_empty') }}Q25267">Celsius</a>. Because it
 is depends on the pressure, this is often also given, as shown in
 <a href="https://www.wikidata.org/wiki/Property:P2102#P1855">these examples</a>.
 
@@ -244,8 +247,9 @@ is depends on the pressure, this is often also given, as shown in
 
 <h2 id="h1">Missing Melting Points</h2>
 
-The <a href="https://www.wikidata.org/wiki/Property:P2101">melting point</a> is the temperature above
-which the compound is fluid. Typical units given include Kelvin and degree Celsius. It is
+The <a href="https://www.wikidata.org/wiki/Property:P2101">melting point</a> is the temperature at which a compound melts. Typical units given include degrees
+<a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degree
+<a href="{{ url_for('app.show_topic_empty') }}Q25267">Celsius</a>. It is
 often found for organic chemicals as part of their unique characterization. Check out
 <a href="https://www.wikidata.org/wiki/Property:P2101#P1855">these examples</a>.
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+
+{% block scripts %}
+{{super()}}
+
+  <script type="text/javascript">
+    missingBoilingPointsSparql = `
+THE SPARQL GOES HERE    
+`
+
+
+ $(document).ready(function() {
+     sparqlToDataTable(missingBoilingPointsSparql, "#missing-boiling-points");
+ });
+
+
+</script>
+
+{% endblock %}
+
+
+{% block page_content %}
+
+<h1 id="h1">Missing Boiling Points</h1>
+
+<table class="table table-hover" id="missing-boiling-points"></table>
+
+
+{% endblock %}

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -11,7 +11,7 @@ SELECT ?compound ?compoundLabel ?formula WITH {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2102 []})
   }
-  LIMIT 500
+  LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -89,7 +89,7 @@ SELECT ?compound ?compoundLabel ?formula WITH {
 }
 `
 
-  missingStandardMolarEnthropySparql = `
+  missingStandardMolarEntropySparql = `
   SELECT ?compound ?compoundLabel ?formula WITH {
   SELECT ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
@@ -193,7 +193,7 @@ $(document).ready(function() {
      sparqlToDataTable(missingSolubilitySparql, "#missing-solubility");
      sparqlToDataTable(missingEnthalpyOfFormationSparql, "#missing-enthalpy-of-formation");
      sparqlToDataTable(missingVaporPressureSparql, "#missing-vapor-pressure");
-     sparqlToDataTable(missingStandardMolarEnthropySparql, "#missing-molar-enthropy");
+     sparqlToDataTable(missingStandardMolarEntropySparql, "#missing-molar-entropy");
      sparqlToDataTable(missingDensitySparql, "#missing-density");
      sparqlToDataTable(missingChemicalStructureSparql, "#missing-chemical-structure");
      sparqlToDataTable(missingFlashPointSparql, "#missing-flash-point");
@@ -233,9 +233,9 @@ $(document).ready(function() {
 
 <table class="table table-hover" id="missing-vapor-pressure"></table>
 
-<h2 id="h1">Missing Molar Enthropy</h2>
+<h2 id="h1">Missing Molar Entropy</h2>
 
-<table class="table table-hover" id="missing-molar-enthropy"></table>
+<table class="table table-hover" id="missing-molar-entropy"></table>
 
 <h2 id="h1">Missing Density</h2>
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -210,55 +210,57 @@ $(document).ready(function() {
 
 {% block page_content %}
 
-<h1 id="h1">Missing Boiling Points</h1>
+<h1>Missing physicalchemical properties for chemicals</h1>
+
+<h2 id="h1">Missing Boiling Points</h2>
 
 <table class="table table-hover" id="missing-boiling-points"></table>
 
-<h1 id="h1">Missing Melting Points</h1>
+<h2 id="h1">Missing Melting Points</h2>
 
 <table class="table table-hover" id="missing-melting-points"></table>
 
-<h1 id="h1">Missing Mass</h1>
+<h2 id="h1">Missing Mass</h2>
 
 <table class="table table-hover" id="missing-mass"></table>
 
-<h1 id="h1">Missing Solubility</h1>
+<h2 id="h1">Missing Solubility</h2>
 
 <table class="table table-hover" id="missing-solubility"></table>
 
-<h1 id="h1">Missing Enthalpy Of Formation</h1>
+<h2 id="h1">Missing Enthalpy Of Formation</h2>
 
 <table class="table table-hover" id="missing-enthalpy-of-formation"></table>
 
-<h1 id="h1">Missing Vapor Pressure</h1>
+<h2 id="h1">Missing Vapor Pressure</h2>
 
 <table class="table table-hover" id="missing-vapor-pressure"></table>
 
-<h1 id="h1">Missing Molar Enthropy</h1>
+<h2 id="h1">Missing Molar Enthropy</h2>
 
 <table class="table table-hover" id="missing-molar-enthropy"></table>
 
-<h1 id="h1">Missing Density</h1>
+<h2 id="h1">Missing Density</h2>
 
 <table class="table table-hover" id="missing-density"></table>
 
-<h1 id="h1">Missing Chemical Structure</h1>
+<h2 id="h1">Missing Chemical Structure</h2>
 
 <table class="table table-hover" id="missing-chemical-structure"></table>
 
-<h1 id="h1">Missing Flash Point</h1>
+<h2 id="h1">Missing Flash Point</h2>
 
 <table class="table table-hover" id="missing-flash-point"></table>
 
-<h1 id="h1">Missing pKa</h1>
+<h2 id="h1">Missing pKa</h2>
 
 <table class="table table-hover" id="missing-pKa"></table>
 
-<h1 id="h1">Missing Combustion Enthalpy</h1>
+<h2 id="h1">Missing Combustion Enthalpy</h2>
 
 <table class="table table-hover" id="missing-combustion-enthalpy"></table>
 
-<h1 id="h1">Missing IDLH</h1>
+<h2 id="h1">Missing IDLH</h2>
 
 <table class="table table-hover" id="missing-idlh"></table>
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -306,7 +306,7 @@ is a measure of the stability of the compound.
 <h2 id="h1">Missing IDLH</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2129">Immediately Dangerous to Life and Health value</a>
-(IDLH) is an indication provided by the U.S.A. CDC about the danger of the compound.
+(IDLH) is an indication provided by the U.S.A. <a href="{{ url_for('app.show_topic_empty') }}Q583725">CDC</a> about the danger of the compound.
 
 <table class="table table-hover" id="missing-idlh"></table>
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -6,184 +6,197 @@
 
   <script type="text/javascript">
     missingBoilingPointsSparql = `
-SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2102 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
  missingMeltingPointsSparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2101 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
   missingMassSparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2067 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
   missingSolubilitySparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-    SELECT ?compound WHERE {
-      ?compound wdt:P31 wd:Q11173.
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
+    ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2177 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
   missingEnthalpyOfFormationSparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P3078 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
   missingVaporPressureSparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2119 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
   missingStandardMolarEntropySparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P3071 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
   missingDensitySparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2054 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
   missingChemicalStructureSparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P117 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
 missingFlashPointSparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2128 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
 missingpKaSparql = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P1117 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
 missingCombustionEnthalpy = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2117 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
 missingIDLH = `
-  SELECT ?compound ?compoundLabel ?formula WITH {
-  SELECT ?compound WHERE {
+SELECT ?wikis ?compound ?compoundLabel ?formula WITH {
+  SELECT (SAMPLE(?wikis_) AS ?wikis) ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2129 []})
-  }
+    OPTIONAL { ?compound wikibase:sitelinks ?wikis_ }
+  } GROUP BY ?compound ORDER BY DESC(?wikis)
   LIMIT 100
 } AS %CHEMICALS WHERE {
   INCLUDE %CHEMICALS
   OPTIONAL { ?compound wdt:P274 ?formula }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
-}
+} ORDER BY DESC(?wikis)
 `
 
 $(document).ready(function() {

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -6,7 +6,7 @@
 
   <script type="text/javascript">
     missingBoilingPointsSparql = `
-SELECT ?compound ?compoundLabel WITH {
+SELECT ?compound ?compoundLabel ?formula WITH {
   SELECT ?compound WHERE {
     ?compound wdt:P31 wd:Q11173.
     FILTER(NOT EXISTS {?compound wdt:P2102 []})

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1439,6 +1439,19 @@ def show_chemical_empty():
     return render_template('chemical_empty.html')
 
 
+@main.route('/chemical/missing')
+def show_chemicals_missing():
+    """Return rendered HTML index page for missing information for chemicals.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML index page for missing information for chemicals.
+
+    """
+    return render_template('chemicals_missing.html')
+
+
 @main.route('/chemical-element/' + q_pattern)
 def show_chemical_element(q):
     """Return html render page for specific chemical element.


### PR DESCRIPTION
- with column on the `/chemical/` frontpage
- adds a few more example chemical structures 

I expect more patches later for more physchem properties from @lahire.