### PR TITLE
adds description to pathway template

### DIFF
--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -92,12 +92,12 @@ ORDER BY DESC(?citations) DESC(?date)
 
 // Extensible query for muliple, optional values
 const optionalDataValuesSparql =`
-SELECT ?wpid ?organism ?organismLabel ?description
+SELECT ?wpid ?organism ?organismLabel ?pathwayDescription
 WHERE {
+  VALUES ?pathway { wd:{{q}} }
   OPTIONAL {
     wd:{{ q }} wdt:P2410 ?wpid ;
-    wdt:P703 ?organism ;
-    schema:description ?description .
+    wdt:P703 ?organism .
   }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,it,jp,nl,no,ru,sv,zh" . }
 }
@@ -121,8 +121,8 @@ $(document).ready(function() {
   $.getJSON(sparqlURL, function(response) {
     const simpleData = sparqlDataToSimpleData(response);
     const dataValues = simpleData.data[0];
-    if ("description" in dataValues) {
-      $("#description").text(dataValues.description);
+    if ("pathwayDescription" in dataValues) {
+      $("#description").text(dataValues.pathwayDescription);
     }
     if ("organism" in dataValues) {
       $("#Organism").after('<a href="'+dataValues.organism+'">'+dataValues.organismLabel+'</a>'); 

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -92,11 +92,12 @@ ORDER BY DESC(?citations) DESC(?date)
 
 // Extensible query for muliple, optional values
 const optionalDataValuesSparql =`
-SELECT ?wpid ?organism ?organismLabel
+SELECT ?wpid ?organism ?organismLabel ?description
 WHERE {
   OPTIONAL {
     wd:{{ q }} wdt:P2410 ?wpid ;
     wdt:P703 ?organism ;
+    schema:description ?description .
   }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,da,de,es,fr,it,jp,nl,no,ru,sv,zh" . }
 }
@@ -120,6 +121,9 @@ $(document).ready(function() {
   $.getJSON(sparqlURL, function(response) {
     const simpleData = sparqlDataToSimpleData(response);
     const dataValues = simpleData.data[0];
+    if ("description" in dataValues) {
+      $("#description").text(dataValues.description);
+    }
     if ("organism" in dataValues) {
       $("#Organism").after('<a href="'+dataValues.organism+'">'+dataValues.organismLabel+'</a>'); 
       organismSection.style.display = "";
@@ -144,6 +148,8 @@ $(document).ready(function() {
 <h1 id="h1">Pathway</h1>
 
 <div id="intro"></div>
+
+<div id="description"></div><br />
 
 <div id="pathway-viewer" class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" src="" style="border-width: 1px; border-color: rgb(222,226,230); border-style: solid;" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>


### PR DESCRIPTION
- Makes use of extensible query for simple values to minimize number of queries
- Uses `div id` pattern
- Display of description matches that of other scholia templates that pull from Wikipedia (thus the `<br />`
- We are responsible for maintaining the wikidata content feeding this new description field and will keep them in sync if future changes are made

Example item with description data: https://tools.wmflabs.org/scholia/pathway/Q66104607