### PR TITLE
Fix #963: Now escapes undefined

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -1,6 +1,14 @@
 // https://stackoverflow.com/questions/6020714
 function escapeHTML(html) {
-    return html.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    if (typeof html !== "undefined") {
+	return html
+	    .replace(/&/g,'&amp;')
+	    .replace(/</g,'&lt;')
+	    .replace(/>/g,'&gt;');
+    }
+    else {
+	return "";
+    }
 }
 
 // http://stackoverflow.com/questions/1026069/


### PR DESCRIPTION
If SPARQL returned empty results a variable that may be used in HTML should be escape with the escapeHTML function. escapeHTML now works with undefined input.