### PR TITLE
Fix #968: Remove tox from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ requests
 simplejson
 werkzeug>=0.9
 urllib3>=1.25.1
-tox


### PR DESCRIPTION
Tox is not necessary for running the program. Tox is only neceesary during
testing.