### PR TITLE
adding H1-level page header to missing page for awards

### DIFF
--- a/scholia/app/templates/award_missing.html
+++ b/scholia/app/templates/award_missing.html
@@ -48,6 +48,11 @@ ORDER BY DESC(?count)
 
 {% block page_content %}
 
+<h1 id="h1">Award</h1>
+
+Missing information with respect to the award.
+
+
 
   <h2>Missing coauthor items</h2>
 


### PR DESCRIPTION
Fixes #982 and also addresses #972