### PR TITLE
Adding a subaspect for organization and topic

### DIFF
--- a/scholia/app/templates/index.html
+++ b/scholia/app/templates/index.html
@@ -109,7 +109,7 @@
 
 		<dl>
 		    <dt>
-		        <a href="Q1305486/topic/Q68854">University of Costa Rica and snakebites</a></dt>
+		        <a href="organization/Q1305486/topic/Q68854">University of Costa Rica and snakebites</a></dt>
             <dd>
 		    Explore what people affiliated with this institution have published on the topic. 
 		    </dd>

--- a/scholia/app/templates/index.html
+++ b/scholia/app/templates/index.html
@@ -84,14 +84,14 @@
 	    
         <div class="card mb-4 box-shadow">
 	    <div class="card-header">
-		<h4 class="my-0 font-weight-normal">Comparisons</h4>
+		<h4 class="my-0 font-weight-normal">Combinations</h4>
 	    </div>
 	    <div class="card-body">
 		<p>Scholia can show multiple items together.</p>
 		
 		<dl>
 		    <dt>
-			<a href="organizations/Q1269766,Q193196">Technical University of Denmark and UCL</a>
+			<a href="organizations/Q1269766,Q193196">Technical University of Denmark and University College London</a>
 		    </dt>
 		    <dd>
 			Compare two or more organizations. Here a comparison between two universities with
@@ -99,11 +99,22 @@
 		    </dd>
 		</dl>
 
-		<dt>
-		    <a href="authors/Q80,Q6135847,Q30085536">Tim Berners-Lee, James Hendler and Ruben Verborgh</a></dt>
-		<dd>
+		<dl>
+		    <dt>
+		        <a href="authors/Q80,Q6135847,Q30085536">Tim Berners-Lee, James Hendler and Ruben Verborgh</a></dt>
+            <dd>
 		    Compare three Semantic Web researchers. 
-		</dd>
+		    </dd>
+		</dl>
+
+		<dl>
+		    <dt>
+		        <a href="Q1305486/topic/Q68854">University of Costa Rica and snakebites</a></dt>
+            <dd>
+		    Explore what people affiliated with this institution have published on the topic. 
+		    </dd>
+		</dl>
+
 
 
 

--- a/scholia/app/templates/organization.html
+++ b/scholia/app/templates/organization.html
@@ -37,11 +37,11 @@ ORDER BY DESC(?works)
  topicsSparql = `
 SELECT
   ?researchers
-  ?topic ?topicLabel ?topicDescription
-  ?Samplework ?SampleworkLabel
-  (CONCAT(
-      "../organization/{{ q }}/topic/",
-      ENCODE_FOR_URI(REPLACE(STR(?topic), ".*Q", "Q"))) AS ?list_url)
+  ?topic ?topicLabel
+  ("🔎" AS ?zoom)
+  (CONCAT("{{ q }}/topic/", SUBSTR(STR(?topic), 32)) AS ?zoomUrl)
+  ?topicDescription
+  ?samplework ?sampleworkLabel
 WITH {
   SELECT DISTINCT ?researcher WHERE {
     ?researcher ( wdt:P108 | wdt:P463 | wdt:P1416 ) / wdt:P361* wd:{{ q }} . 
@@ -50,7 +50,7 @@ WITH {
 WITH {
   SELECT DISTINCT ?topic
     (COUNT(DISTINCT ?researcher) AS ?researchers)
-    (SAMPLE(?work) AS ?Samplework)
+    (SAMPLE(?work) AS ?samplework)
   WHERE {
     INCLUDE %researchers
     ?work wdt:P50 ?researcher . 
@@ -64,7 +64,7 @@ WHERE {
   INCLUDE %works_and_number_of_researchers
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . } 
 }
-GROUP BY ?researchers ?topic ?topicLabel ?topicDescription ?Samplework ?SampleworkLabel
+GROUP BY ?researchers ?topic ?topicLabel ?topicDescription ?samplework ?sampleworkLabel
 ORDER BY DESC(?researchers)
    `;
 
@@ -157,7 +157,10 @@ WHERE {
  $(document).ready(function() {
      sparqlToDataTable(employeesAndAffiliatedSparql, "#employees-and-affiliated");
      sparqlToDataTable(topicsSparql, "#topics", {
-	     linkPrefixes:{"list": "../../../{{listLabel}}"} });
+	 linkPrefixes:{
+	     "topic": "../topic/",
+	     "samplework": "../work/",
+	 }});
      sparqlToDataTable(recentPublicationsSparql, "#recent-publications");
      sparqlToDataTable(recentCitationsSparql, "#recent-citations");
      sparqlToDataTable(awardsSparql, "#awards");

--- a/scholia/app/templates/organization.html
+++ b/scholia/app/templates/organization.html
@@ -34,6 +34,40 @@ GROUP BY ?researcher ?researcherLabel ?researcherDescription
 ORDER BY DESC(?works)
  `;
 
+ topicsSparql = `
+SELECT
+  ?researchers
+  ?topic ?topicLabel ?topicDescription
+  ?Samplework ?SampleworkLabel
+  (CONCAT(
+      "../organization/{{ q }}/topic/",
+      ENCODE_FOR_URI(REPLACE(STR(?topic), ".*Q", "Q"))) AS ?list_url)
+WITH {
+  SELECT DISTINCT ?researcher WHERE {
+    ?researcher ( wdt:P108 | wdt:P463 | wdt:P1416 ) / wdt:P361* wd:{{ q }} . 
+  } 
+} AS %researchers
+WITH {
+  SELECT DISTINCT ?topic
+    (COUNT(DISTINCT ?researcher) AS ?researchers)
+    (SAMPLE(?work) AS ?Samplework)
+  WHERE {
+    INCLUDE %researchers
+    ?work wdt:P50 ?researcher . 
+    ?work wdt:P921 ?topic . 
+  } 
+  GROUP BY ?topic
+  ORDER BY DESC(?researchers)
+  LIMIT 500
+} AS %works_and_number_of_researchers
+WHERE {
+  INCLUDE %works_and_number_of_researchers
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh" . } 
+}
+GROUP BY ?researchers ?topic ?topicLabel ?topicDescription ?Samplework ?SampleworkLabel
+ORDER BY DESC(?researchers)
+   `;
+
  recentPublicationsSparql = `
 #defaultView:Table
 SELECT
@@ -122,6 +156,8 @@ WHERE {
 
  $(document).ready(function() {
      sparqlToDataTable(employeesAndAffiliatedSparql, "#employees-and-affiliated");
+     sparqlToDataTable(topicsSparql, "#topics", {
+	     linkPrefixes:{"list": "../../../{{listLabel}}"} });
      sparqlToDataTable(recentPublicationsSparql, "#recent-publications");
      sparqlToDataTable(recentCitationsSparql, "#recent-citations");
      sparqlToDataTable(awardsSparql, "#awards");
@@ -165,6 +201,11 @@ Past and present employees, affiliated, and members<br/>
 </div>
 
 
+<h2 id="Topics that employees and affiliates have published on">Topics that employees and affiliates have published on</h2>
+
+Topics of publications by past and present employees, affiliates, and members, ranked by number of individuals having published on the topic.<br/>
+
+<table class="table table-hover" id="topics"></table>
 
 <h2 id="Recent-publications">Recent publications <a href="{{ url_for('app.show_organization_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 

--- a/scholia/app/templates/organization_empty.html
+++ b/scholia/app/templates/organization_empty.html
@@ -32,4 +32,15 @@ Universities, research centers, ...
 </ul>
 
 
+<h3>Subaspect: Organizations and topics</h3>
+
+<ul>
+  <li><a href="Q19375720/topic/Q202864">Institut Louis-Malardé and Zika virus</a></li>
+  <li><a href="Q1062129/topic/Q1137203">Tohoku University and thin films</a></li>
+  <li><a href="Q649998/topic/Q6786626">University of Nairobi and maternal health</a></li>
+  <li><a href="Q1285262/topic/Q179918">University of Alaska Fairbanks and permafrost</a></li>
+</ul>
+
+
+
 {% endblock %}

--- a/scholia/app/templates/organization_topic.html
+++ b/scholia/app/templates/organization_topic.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block scripts %}
+{{super()}}
+
+<script type="text/javascript">
+    organizationTopicsSparql = `
+SELECT DISTINCT ?work ?workLabel ?author ?authorLabel ?publication_date WHERE {
+  { ?author ?p1 wd:{{ q1 }}. }
+  UNION
+  {
+    ?author ?p2 ?something .
+    ?something wdt:P361 wd:{{ q1 }}.
+  }
+  ?work wdt:P50 ?author;
+    wdt:P921 wd:{{ q2 }}.
+  OPTIONAL { ?work wdt:P577 ?publication_date. }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+GROUP BY ?work ?workLabel ?author ?authorLabel ?publication_date
+ORDER BY DESC (?publication_date)
+LIMIT 200
+`;
+
+
+ $(document).ready(function() {
+     sparqlToDataTable(
+	 organizationTopicsSparql, "#topics", {
+	     linkPrefixes:{"author": "../../../author/",
+			   "work": "../../../work/"} });
+ });
+</script>
+
+
+{% endblock %}
+
+
+
+{% block page_content %}
+
+<h1 id="h1">Organization-topic</h1>
+
+<div id="intro"></div>
+
+
+<h2 id="Recent publications">Recent publications</h2>
+
+<table class="table table-hover" id="topics"></table>
+
+
+{% endblock %}

--- a/scholia/app/templates/organization_topic.html
+++ b/scholia/app/templates/organization_topic.html
@@ -4,8 +4,11 @@
 {{super()}}
 
 <script type="text/javascript">
-    organizationTopicsSparql = `
-SELECT DISTINCT ?work ?workLabel ?author ?authorLabel ?publication_date WHERE {
+    recentPublicationsSparql = `
+SELECT
+  (xsd:date(MAX(?publication_date_)) AS ?publication_date)
+  ?work ?workLabel ?author ?authorLabel 
+WHERE {
   { ?author ?p1 wd:{{ q1 }}. }
   UNION
   {
@@ -13,21 +16,22 @@ SELECT DISTINCT ?work ?workLabel ?author ?authorLabel ?publication_date WHERE {
     ?something wdt:P361 wd:{{ q1 }}.
   }
   ?work wdt:P50 ?author;
-    wdt:P921 wd:{{ q2 }}.
-  OPTIONAL { ?work wdt:P577 ?publication_date. }
+  wdt:P921 wd:{{ q2 }}.
+  OPTIONAL { ?work wdt:P577 ?publication_date_ . }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 }
-GROUP BY ?work ?workLabel ?author ?authorLabel ?publication_date
+GROUP BY ?work ?workLabel ?author ?authorLabel 
 ORDER BY DESC (?publication_date)
 LIMIT 200
 `;
 
 
- $(document).ready(function() {
-     sparqlToDataTable(
-	 organizationTopicsSparql, "#topics", {
-	     linkPrefixes:{"author": "../../../author/",
-			   "work": "../../../work/"} });
+  $(document).ready(function() {
+      sparqlToDataTable(
+	  recentPublicationsSparql, "#recent-publications", {
+	      linkPrefixes:{
+		  "author": "../../../author/",
+		  "work": "../../../work/"} });
  });
 </script>
 
@@ -43,9 +47,9 @@ LIMIT 200
 <div id="intro"></div>
 
 
-<h2 id="Recent publications">Recent publications</h2>
+<h2 class="headline" id="Recent-publications"><a href="#Recent-publications">Recent publications</a></h2>
 
-<table class="table table-hover" id="topics"></table>
+<table class="table table-hover" id="recent-publications"></table>
 
 
 {% endblock %}

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -1008,6 +1008,26 @@ def show_organization_rss(q):
     return response
 
 
+@main.route('/organization/' + q1_pattern + '/topic/' + q2_pattern)
+def show_organization_topic(q1, q2):
+    """Return HTML rendering for specific organization and topic.
+
+    Parameters
+    ----------
+    q1 : str
+        Wikidata item identifier for organization.
+    q2 : str
+        Wikidata item identifier for topic
+
+    Returns
+    -------
+    html : str
+        Rendered HTML for a specific organization and topic.
+
+    """
+    return render_template('organization_topic.html', q1=q1, q2=q2, q=q1)
+
+
 @main.route('/organization/' + q_pattern + '/missing')
 def show_organization_missing(q):
     """Return HTML rendering for missing information about an organization.


### PR DESCRIPTION
This adds a topic subaspect for an organization profile and links to it from 
- an organization's profile
- the organization aspect's landing page (for some examples)
- the Scholia landing page (for one example).

Fixes #437 .