### PR TITLE
Adding an example for comparing 7 authors

### DIFF
--- a/scholia/app/templates/author_empty.html
+++ b/scholia/app/templates/author_empty.html
@@ -85,6 +85,9 @@ Researcher with a published record.
 
 		    <dt><a href="../authors/Q38084489,Q38085379,Q38084725,Q38084995">Anders Eklund, Anders Eklund, Anders Eklund, and Anders Eklund</a></dt>
 		    <dd>Where would we be without identifiers...</dd>
+
+		    <dt><a href="../authors/Q71522746,Q28468766,Q28468763,Q24532211,Q24244119,Q24727868,Q78549817">Teheipuaura Mariteragi-Helle, Maite Aubry, Jean-Claude Manuguerra, Van-Mai Cao-Lormeau, Didier Musso, Anita Teissier, Mike Kama</a></dt>
+		    <dd>Seven researchers studying infectious diseases in the Pacific region</dd>
 		</dl>
 
 


### PR DESCRIPTION
Adds a link from
https://tools.wmflabs.org/scholia/author/
to
https://tools.wmflabs.org/scholia/authors/Q71522746,Q28468766,Q28468763,Q24532211,Q24244119,Q24727868,Q78549817