### PR TITLE
Closing #608

### DIFF
--- a/scholia/app/templates/author_missing.html
+++ b/scholia/app/templates/author_missing.html
@@ -6,27 +6,31 @@
 
   <script type="text/javascript">
     missingAuthorResolvingSparql = `
-SELECT
+SELECT 
   (COUNT(?work) AS ?count) 
-  ?author_name
-  (CONCAT(
-      'https://tools.wmflabs.org/author-disambiguator/?doit=Look+for+author&name=',
-      ENCODE_FOR_URI(?author_name)) AS ?author_resolver_url)
+  ?author_name 
+  (CONCAT("https://tools.wmflabs.org/author-disambiguator/?doit=Look+for+author&name=", 
+          ENCODE_FOR_URI(?author_name)) AS ?author_resolver_url) 
 WHERE {
   {
-    SELECT DISTINCT ?author_name {
-      wd:{{ q }} skos:altLabel | rdfs:label ?author_name_ .
-      
-      # The SELECT-DISTINCT-BIND trick here is due to Stanislav Kralin
-      # https://stackoverflow.com/questions/53933564
-      BIND (STR(?author_name_) AS ?author_name)
+    SELECT DISTINCT ?author_name WHERE {
+      {
+        { wd:{{ q }} skos:altLabel ?author_name_. }
+        UNION
+        { wd:{{ q }} rdfs:label ?author_name_. }
+        BIND(STR(?author_name_) AS ?author_name)
+      }
+      UNION
+      {
+        ?author_statement ps:P50 wd:{{ q }};
+          pq:P1932 ?author_name.
+      }
     }
   }
-  OPTIONAL { ?work wdt:P2093 ?author_name . }
+  OPTIONAL { ?work wdt:P2093 ?author_name. }
 }
-GROUP BY ?author_name 
-ORDER BY DESC(?count)
-
+GROUP BY ?author_name
+ORDER BY DESC (?count)
 `
 
  missingCoauthorItemsSparql = `


### PR DESCRIPTION
Modified the query for "Author name strings to be resolved" on the /missing page for authors, such that it includes strings that occur in "stated as" qualifiers for P50 (author) statements involving this entity on publicaiton items.