### PR TITLE
better text about author disambiguation on the missing page for authors

### DIFF
--- a/scholia/app/templates/author_missing.html
+++ b/scholia/app/templates/author_missing.html
@@ -162,8 +162,8 @@ Missing information with respect to the author.
 
 <h2>Author name strings to be resolved</h2>
 
-The author may be represented as a string rather than a Wikidata item.
-Follow the link to use the Author disambiguator tool to try to resolve the author name.
+The authorship may be represented as an author name string rather than a Wikidata item.
+To try to resolve the author name strings, follow the links below to use the Author disambiguator tool, which also has a <a href="https://tools.wmflabs.org/author-disambiguator/author_item_oauth.php?id={{ q }}">dedicated page for this author</a>.
 
 <table class="table table-hover" id="missing-author-resolving"></table>
 


### PR DESCRIPTION
better text about author disambiguation on the missing page for authors