### PR TITLE
Added NCBI gene and taxon IDs to the UI

### DIFF
--- a/scholia/app/templates/gene_empty.html
+++ b/scholia/app/templates/gene_empty.html
@@ -45,7 +45,7 @@ Genes.
 		<p>If you know the identifier then Scholia can make a lookup based on the identifier:</p>
 
 		<dl>
-		    <dt><a href="ncbi/5604">gene/ncbi/5604</a></dt>
+		    <dt><a href="../ncbi-gene/5604">ncbi-gene/5604</a></dt>
 		    <dd>Information on MAP2K1 based on the NCBI (Entrez) gene identifier.</dd>
 		</dl>
 	    </div>

--- a/scholia/app/templates/gene_empty.html
+++ b/scholia/app/templates/gene_empty.html
@@ -6,13 +6,53 @@
 
 Genes.
 
-<h2>Examples</h2>
+<div class="container">
 
-<ul>
-  <li><a href="Q18030793">MAP2K1 (<em>Homo sapiens</em>)</a></li>
-  <li><a href="Q14860818">SLC6A4 (serotonin transporter gene in <em>Homo sapiens</em>)</a></li>
-  <li><a href="Q14891424">HTR2A (<em>Homo sapiens</em>)</a></li>
-</ul>
+    <h2>Examples</h2>
+
+    <div class="card-deck mb-3">
+	<div class="card mb-4 box-shadow">
+
+            <div class="card-header">
+		<h4 class="my-0 font-weight-normal">Single items</h4>
+            </div>
+            <div class="card-body">
+		<dl>
+		    <dt><a href="Q18030793">MAP2K1</a></dt>
+		    <dd>
+			Human gene.
+		    </dd>
+
+		    <dt><a href="Q14860818">SLC6A4</a></dt>
+		    <dd>
+			Serotonin transporter gene in <em>Homo sapiens</em>.
+		    </dd>
+
+		    <dt><a href="Q14891424">HTR2A</a></dt>
+		    <dd>
+			Human gene.
+		    </dd>
+		</dl>
+            </div>
+
+	</div>
+
+     <div class="card mb-4 box-shadow">
+	    <div class="card-header">
+		    <h4 class="my-0 font-weight-normal">Redirecting</h4>
+	    </div>
+	    <div class="card-body">
+		<p>If you know the identifier then Scholia can make a lookup based on the identifier:</p>
+
+		<dl>
+		    <dt><a href="ncbi/5604">gene/ncbi/5604</a></dt>
+		    <dd>Information on MAP2K1 based on the NCBI (Entrez) gene identifier.</dd>
+		</dl>
+	    </div>
+        </div>
+    </div>
+</div>
+
 
 {% endblock %}
 

--- a/scholia/app/templates/taxon_empty.html
+++ b/scholia/app/templates/taxon_empty.html
@@ -4,14 +4,60 @@
 
 <h1>Taxa</h1>
 
-<h2>Examples</h2>
+<div class="container">
 
-<ul>
-  <li><a href="Q15978631">Human (<em>Homo sapiens</em>)</a></li>
-  <li><a href="Q12024">Pine (<em>Pinus</em>)</a></li>
-  <li><a href="Q25485">Great tit (<em>Parus major</em>)</a></li>
-  <li><a href="Q91703">The C. elegans roundworm (<em>Caenorhabditis elegans</em>)</a></li>
-</ul>
+    <h2>Examples</h2>
+
+    <div class="card-deck mb-3">
+	<div class="card mb-4 box-shadow">
+
+            <div class="card-header">
+		<h4 class="my-0 font-weight-normal">Single items</h4>
+            </div>
+            <div class="card-body">
+		<dl>
+		    <dt><a href="Q15978631">Human</a></dt>
+		    <dd>
+			View information about Homo sapiens.
+		    </dd>
+
+		    <dt><a href="Q12024">Pine</a></dt>
+		    <dd>
+			Information about the Pinus family.
+		    </dd>
+
+		    <dt><a href="Q25485">Parus major</a></dt>
+		    <dd>
+			Great tit.
+		    </dd>
+
+		    <dt><a href="Q91703">Caenorhabditis elegans</a></dt>
+		    <dd>
+			The C. elegans roundworm
+		    </dd>
+		</dl>
+            </div>
+
+	</div>
+
+     <div class="card mb-4 box-shadow">
+	    <div class="card-header">
+		    <h4 class="my-0 font-weight-normal">Redirecting</h4>
+	    </div>
+	    <div class="card-body">
+		<p>If you know the identifier then Scholia can make a lookup based on the identifier:</p>
+
+		<dl>
+		    <dt><a href="ncbi/694009">taxon/ncbi/694009</a></dt>
+		    <dd>Information on SARSr-CoV.</dd>
+		</dl>
+	    </div>
+        </div>
+    </div>
+</div>
+
+</div>
+
 
 {% endblock %}
 

--- a/scholia/app/templates/taxon_empty.html
+++ b/scholia/app/templates/taxon_empty.html
@@ -48,7 +48,7 @@
 		<p>If you know the identifier then Scholia can make a lookup based on the identifier:</p>
 
 		<dl>
-		    <dt><a href="ncbi/694009">taxon/ncbi/694009</a></dt>
+		    <dt><a href="../ncbi-taxon/694009">ncbi-taxon/694009</a></dt>
 		    <dd>Information on SARSr-CoV.</dd>
 		</dl>
 	    </div>

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -18,7 +18,8 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      q_to_class, random_author, twitter_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
-                     pubchem_to_qs, atomic_number_to_qs, ncbitaxon_to_qs)
+                     pubchem_to_qs, atomic_number_to_qs, ncbitaxon_to_qs,
+                     ncbigene_to_qs)
 from ..utils import sanitize_q
 from ..wikipedia import q_to_bibliography_templates
 
@@ -700,6 +701,22 @@ def show_faq():
     """
     return render_template('faq.html')
 
+
+@main.route('/gene/ncbi/<gene>')
+def redirect_ncbigene(gene):
+    """Detect and redirect for NCBI gene identifiers.
+
+    Parameters
+    ----------
+    gene : str
+        NCBI gene identifier.
+
+    """
+    qs = ncbigene_to_qs(gene)
+    if len(qs) > 0:
+        q = qs[0]
+        return redirect(url_for('app.show_gene', q=q), code=302)
+    return render_template('404.html')
 
 @main.route('/github/<github>')
 def redirect_github(github):

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -18,7 +18,7 @@ from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      q_to_class, random_author, twitter_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
-                     pubchem_to_qs, atomic_number_to_qs)
+                     pubchem_to_qs, atomic_number_to_qs, ncbitaxon_to_qs)
 from ..utils import sanitize_q
 from ..wikipedia import q_to_bibliography_templates
 
@@ -903,6 +903,21 @@ def redirect_pubmed(pmid):
         return redirect(url_for('app.show_work', q=q), code=302)
     return render_template('404.html')
 
+@main.route('/taxon/ncbi/<taxon>')
+def redirect_ncbitaxon(taxon):
+    """Detect and redirect for NCBI taxon identifiers.
+
+    Parameters
+    ----------
+    taxon : str
+        NCBI taxon identifier.
+
+    """
+    qs = ncbitaxon_to_qs(taxon)
+    if len(qs) > 0:
+        q = qs[0]
+        return redirect(url_for('app.show_taxon', q=q), code=302)
+    return render_template('404.html')
 
 @main.route('/wikipathways/<wpid>')
 def redirect_wikipathways(wpid):

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -718,6 +718,7 @@ def redirect_ncbigene(gene):
         return redirect(url_for('app.show_gene', q=q), code=302)
     return render_template('404.html')
 
+
 @main.route('/github/<github>')
 def redirect_github(github):
     """Detect and redirect for Github user.
@@ -920,6 +921,7 @@ def redirect_pubmed(pmid):
         return redirect(url_for('app.show_work', q=q), code=302)
     return render_template('404.html')
 
+
 @main.route('/taxon/ncbi/<taxon>')
 def redirect_ncbitaxon(taxon):
     """Detect and redirect for NCBI taxon identifiers.
@@ -935,6 +937,7 @@ def redirect_ncbitaxon(taxon):
         q = qs[0]
         return redirect(url_for('app.show_taxon', q=q), code=302)
     return render_template('404.html')
+
 
 @main.route('/wikipathways/<wpid>')
 def redirect_wikipathways(wpid):

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -702,7 +702,7 @@ def show_faq():
     return render_template('faq.html')
 
 
-@main.route('/gene/ncbi/<gene>')
+@main.route('/ncbi-gene/<gene>')
 def redirect_ncbigene(gene):
     """Detect and redirect for NCBI gene identifiers.
 
@@ -922,7 +922,7 @@ def redirect_pubmed(pmid):
     return render_template('404.html')
 
 
-@main.route('/taxon/ncbi/<taxon>')
+@main.route('/ncbi-taxon/<taxon>')
 def redirect_ncbitaxon(taxon):
     """Detect and redirect for NCBI taxon identifiers.
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -388,6 +388,42 @@ def ror_to_qs(rorid):
             for item in data['results']['bindings']]
 
 
+def ncbigene_to_qs(gene):
+    """Convert a NCBI gene identifier to Wikidata ID.
+
+    Wikidata Query Service is used to resolve the NCBI gene identifier.
+
+    The NCBI gene identifier string is converted to uppercase before any
+    query is made.
+
+    Parameters
+    ----------
+    gene : str
+        NCBI gene identifier
+
+    Returns
+    -------
+    qs : list of str
+        List of strings with Wikidata IDs.
+
+    Examples
+    --------
+    >>> ncbitaxon_to_qs('694009') == ['Q278567']
+    True
+
+    """
+    query = 'select ?work where {{ ?work wdt:P351 "{gene}" }}'.format(
+        gene=gene)
+
+    url = 'https://query.wikidata.org/sparql'
+    params = {'query': query, 'format': 'json'}
+    response = requests.get(url, params=params, headers=HEADERS)
+    data = response.json()
+
+    return [item['work']['value'][31:]
+            for item in data['results']['bindings']]
+
+
 def ncbitaxon_to_qs(taxon):
     """Convert a NCBI taxon identifier to Wikidata ID.
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -14,6 +14,8 @@ Usage:
   scholia.query lipidmaps-to-q <lmid>
   scholia.query atomic-number-to-q <atomicnumber>
   scholia.query mesh-to-q <meshid>
+  scholia.query ncbigene-to-q <gene>
+  scholia.query ncbitaxon-to-q <taxon>
   scholia.query orcid-to-q <orcid>
   scholia.query pubchem-to-q <cid>
   scholia.query pubmed-to-q <pmid>
@@ -412,7 +414,7 @@ def ncbigene_to_qs(gene):
     True
 
     """
-    query = 'select ?work where {{ ?work wdt:P351 "{gene}" }}'.format(
+    query = 'select ?gene where {{ ?gene wdt:P351 "{gene}" }}'.format(
         gene=gene)
 
     url = 'https://query.wikidata.org/sparql'
@@ -420,7 +422,7 @@ def ncbigene_to_qs(gene):
     response = requests.get(url, params=params, headers=HEADERS)
     data = response.json()
 
-    return [item['work']['value'][31:]
+    return [item['gene']['value'][31:]
             for item in data['results']['bindings']]
 
 
@@ -1375,6 +1377,16 @@ def main():
 
     elif arguments['mesh-to-q']:
         qs = mesh_to_qs(arguments['<meshid>'])
+        if len(qs) > 0:
+            print(qs[0])
+
+    elif arguments['ncbigene-to-q']:
+        qs = ncbigene_to_qs(arguments['<gene>'])
+        if len(qs) > 0:
+            print(qs[0])
+
+    elif arguments['ncbitaxon-to-q']:
+        qs = ncbitaxon_to_qs(arguments['<taxon>'])
         if len(qs) > 0:
             print(qs[0])
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -14,8 +14,8 @@ Usage:
   scholia.query lipidmaps-to-q <lmid>
   scholia.query atomic-number-to-q <atomicnumber>
   scholia.query mesh-to-q <meshid>
-  scholia.query ncbigene-to-q <gene>
-  scholia.query ncbitaxon-to-q <taxon>
+  scholia.query ncbi-gene-to-q <gene>
+  scholia.query ncbi-taxon-to-q <taxon>
   scholia.query orcid-to-q <orcid>
   scholia.query pubchem-to-q <cid>
   scholia.query pubmed-to-q <pmid>
@@ -410,7 +410,7 @@ def ncbigene_to_qs(gene):
 
     Examples
     --------
-    >>> ncbitaxon_to_qs('694009') == ['Q278567']
+    >>> ncbi-taxon_to_qs('694009') == ['Q278567']
     True
 
     """
@@ -446,7 +446,7 @@ def ncbitaxon_to_qs(taxon):
 
     Examples
     --------
-    >>> ncbitaxon_to_qs('694009') == ['Q278567']
+    >>> ncbi-taxon_to_qs('694009') == ['Q278567']
     True
 
     """
@@ -1380,12 +1380,12 @@ def main():
         if len(qs) > 0:
             print(qs[0])
 
-    elif arguments['ncbigene-to-q']:
+    elif arguments['ncbi-gene-to-q']:
         qs = ncbigene_to_qs(arguments['<gene>'])
         if len(qs) > 0:
             print(qs[0])
 
-    elif arguments['ncbitaxon-to-q']:
+    elif arguments['ncbi-taxon-to-q']:
         qs = ncbitaxon_to_qs(arguments['<taxon>'])
         if len(qs) > 0:
             print(qs[0])

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -388,6 +388,42 @@ def ror_to_qs(rorid):
             for item in data['results']['bindings']]
 
 
+def ncbitaxon_to_qs(taxon):
+    """Convert a NCBI taxon identifier to Wikidata ID.
+
+    Wikidata Query Service is used to resolve the NCBI taxon identifier.
+
+    The NCBI taxon identifier string is converted to uppercase before any
+    query is made.
+
+    Parameters
+    ----------
+    taxon : str
+        NCBI taxon identifier
+
+    Returns
+    -------
+    qs : list of str
+        List of strings with Wikidata IDs.
+
+    Examples
+    --------
+    >>> ncbitaxon_to_qs('694009') == ['Q278567']
+    True
+
+    """
+    query = 'select ?work where {{ ?work wdt:P685 "{taxon}" }}'.format(
+        taxon=taxon)
+
+    url = 'https://query.wikidata.org/sparql'
+    params = {'query': query, 'format': 'json'}
+    response = requests.get(url, params=params, headers=HEADERS)
+    data = response.json()
+
+    return [item['work']['value'][31:]
+            for item in data['results']['bindings']]
+
+
 def wikipathways_to_qs(wpid):
     """Convert a WikiPathways identifier to Wikidata ID.
 


### PR DESCRIPTION
Adds two CLI methods:

* `python -m scholia.query ncbitaxon-to-q 694009`
* `python -m scholia.query ncbigene-to-q 5604`

Second, it upgrades the empty `gene` and `taxon` aspects with the column layout, featuring the two redirects, here for taxon:

![image](https://user-images.githubusercontent.com/26721/77821880-e208a980-70ed-11ea-9b3c-e11f08da47b9.png)

**Important**: unlike with most other redirects, I decided here to use simply `ncbi`, but because ncbi has many identifiers, I use the aspect as context.
