### PR TITLE
Add link to OpenTrials

### DIFF
--- a/scholia/app/templates/clinical_trial.html
+++ b/scholia/app/templates/clinical_trial.html
@@ -74,7 +74,7 @@ WHERE {
     BIND(100 AS ?order)
     BIND("ClinicalTrials.gov" AS ?description)
     ?trial wdt:P3098 ?value_ .
-    BIND(CONCAT(?value_, " 🔗") AS ?value)
+    BIND(CONCAT(?value_, " ↗") AS ?value)
     BIND(CONCAT("https://clinicaltrials.gov/show/", ?value_) AS ?valueUrl)
   }
 
@@ -83,8 +83,17 @@ WHERE {
     BIND(101 AS ?order)
     BIND("ClinWiki" AS ?description)
     ?trial wdt:P3098 ?value_ .
-    BIND(CONCAT(?value_, " 🔗") AS ?value)
+    BIND(CONCAT(?value_, " ↗") AS ?value)
     BIND(CONCAT("https://www.clinwiki.org/study/", ?value_) AS ?valueUrl)
+  }
+
+  UNION
+  {
+    BIND(103 AS ?order)
+    BIND("OpenTrials" AS ?description)
+    ?trial wdt:P6220 ?value_ .
+    BIND(CONCAT(?value_, " ↗") AS ?value)
+    BIND(CONCAT("https://explorer.opentrials.net/trials/", ?value_) AS ?valueUrl)
   }
 
 } 


### PR DESCRIPTION
Add link to OpenTrials via its identifier implementing #621
The icon that indicates an external link is also changed to a northeast arrow.