### PR TITLE
Fix problem with arxiv scraping #1059

### DIFF
--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -39,6 +39,8 @@ import requests
 
 USER_AGENT = 'Scholia'
 
+ARXIV_URL = 'https://export.arxiv.org/'
+
 
 def get_metadata(arxiv):
     """Get metadata about an arxiv publication from website.
@@ -77,12 +79,16 @@ def get_metadata(arxiv):
 
     """
     arxiv = arxiv.strip()
-    url = 'https://arxiv.org/abs/' + arxiv
+    url = ARXIV_URL + '/abs/' + arxiv
     headers = {'User-agent': USER_AGENT}
     response = requests.get(url, headers=headers)
     tree = etree.HTML(response.content)
 
     submissions = tree.xpath('//div[@class="submission-history"]/text()')
+    submissions = [submission
+                   for submission in submissions
+                   if len(submission.strip()) > 0
+    ]
     datetime_as_string = submissions[-1][5:30]
     isodatetime = parse_datetime(datetime_as_string).isoformat()
 

--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -85,9 +85,10 @@ def get_metadata(arxiv):
     tree = etree.HTML(response.content)
 
     submissions = tree.xpath('//div[@class="submission-history"]/text()')
-    submissions = [submission
-                   for submission in submissions
-                   if len(submission.strip()) > 0
+    submissions = [
+        submission
+        for submission in submissions
+        if len(submission.strip()) > 0
     ]
     datetime_as_string = submissions[-1][5:30]
     isodatetime = parse_datetime(datetime_as_string).isoformat()

--- a/scholia/tex.py
+++ b/scholia/tex.py
@@ -387,11 +387,11 @@ def main():
         for doi in dois:
             qs_doi = doi_to_qs(doi)
             if len(qs_doi) == 0:
-                print('Could not find Wikidata item for {doi}'.format(doi))
+                print('Could not find Wikidata item for {doi}'.format(doi=doi))
                 continue
             if len(qs_doi) > 1:
                 print(('Multiple Wikidata items for {doi}: {qs}.'
-                       'Using first.').format(doi, qs_doi))
+                       'Using first.').format(doi=doi, qs=qs_doi))
             q = qs_doi[0]
             qs.append(q)
             keys.append(doi)

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -15,3 +15,6 @@ def test_get_metadata():
     metadata = get_metadata('1803.04349')
     assert metadata['publication_date'] == '2018-03-05'
     assert metadata['full_text_url'] == "https://arxiv.org/pdf/1803.04349.pdf"
+
+    metadata = get_metadata('1710.04099')
+    assert metadata['publication_date'] == '2017-10-11'


### PR DESCRIPTION
The datetime was not extracted correctly.
The URL for scraping has been changed to export.arxiv.org.