### PR TITLE
Give all sections on all Scholia pages section IDs (Issue fix #1157)

### DIFF
--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -379,9 +379,9 @@ ORDER BY ?publication_date
 
 <div id="details"></div>
 
-<h2>List of publications <a href="{{ url_for('app.show_author_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="list-of-publications">List of publications <a href="{{ url_for('app.show_author_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<table class="table table-hover" id="list-of-publications"></table>
+<table class="table table-hover" id="list-of-publications-table"></table>
 
 
 <!--      SourceMD does currently not work

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -401,35 +401,35 @@ div>
 </div -->
 
 
-<h3 id="Number of publications per year">Number of publications per year</h3>
+<h3 id="number-of-publications-per-year">Number of publications per year</h3>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="number-of-publications-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0A%23%20Inspired%20from%20LEGOLAS%20-%20http%3A%2F%2Fabel.lis.illinois.edu%2Flegolas%2F%0A%23%20Shubhanshu%20Mishra%2C%20Vetle%20Torvik%0Aselect%20%3Fyear%20%28count%28%3Fwork%29%20as%20%3Fnumber_of_publications%29%20%3Frole%20where%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%28str%28%3Fyear_%29%20as%20%3Fyear%29%20%280%20as%20%3Fpages%29%20%28%22_%22%20as%20%3Frole%29%20where%20%7B%0A%20%20%20%20%20%20%23%20default%20values%20%3D%200%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20%20%20bind%28year%28%3Fdate%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20select%20%28min%28%3Fyear_%29%20as%20%3Fearliest_year%29%20%20%28max%28%3Fyear_%29%20as%20%3Flatest_year%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fpublication_date%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20bind%28year%28now%28%29%29%2B1%20as%20%3Fnext_year%29%0A%20%20%20%20%20%20filter%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Flatest_year%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20union%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%3Fwork%20%28min%28%3Fyears%29%20as%20%3Fyear%29%20%28count%28%3Fcoauthors%29%20as%20%3Fnumber_of_authors%29%20%3Fauthor_number%20where%20%7B%0A%20%20%20%20%20%20%3Fwork%20%28p%3AP50%7Cp%3AP2093%29%20%3Fauthor_statement%20.%20%0A%20%20%20%20%20%20%3Fauthor_statement%20ps%3AP50%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20optional%20%7B%20%3Fauthor_statement%20pq%3AP1545%20%3Fauthor_number%20.%20%7D%0A%20%20%20%20%20%20%3Fwork%20%28wdt%3AP50%7Cwdt%3AP2093%29%20%3Fcoauthors%20.%20%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdates%20.%0A%20%20%20%20%20%20bind%28str%28year%28%3Fdates%29%29%20as%20%3Fyears%29%20.%0A%20%20%20%20%7D%0A%20%20%20%20group%20by%20%3Fwork%20%3Fauthor_number%0A%20%20%7D%0A%20%20bind%28coalesce%28if%28%3Fnumber_of_authors%20%3D%201%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%27Solo%20author%27%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20if%28xsd%3Ainteger%28%3Fauthor_number%29%20%3D%201%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27First%20author%27%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%28xsd%3Ainteger%28%3Fauthor_number%29%20%3D%20%3Fnumber_of_authors%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27Last%20author%27%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27Middle%20author%27%29%29%29%2C%20%27Unknown%27%29%0A%20%20%20%20%20%20%20as%20%3Frole%29%0A%20%20%20%7D%0A%7D%0Agroup%20by%20%3Fyear%20%3Frole%0Aorder%20by%20%3Fyear"></iframe>
 </div>
 
 
-<h3 id="Number of pages per year">Number of pages per year</h3>
+<h3 id="number-of-pages-per-year">Number of pages per year</h3>
 
 (Only articles with number of pages set are displayed)
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="number-of-pages-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0Aselect%20%3Fyear%20%3Fnumber_of_pages%20%3Fwork_label%20where%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%3Fyear%20%28sample%28%3Fpages%29%20as%20%3Fnumber_of_pages%29%20%3Fwork_label%20where%20%7B%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20select%20%28str%28%3Fyear_%29%20as%20%3Fyear%29%20%280%20as%20%3Fpages%29%20%28%22_%22%20as%20%3Fwork_label%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%20%20%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fdate%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20select%20%28min%28%3Fyear_%29%20as%20%3Fearliest_year%29%20%28max%28%3Fyear_%29%20as%20%3Flatest_year%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fpublication_date%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20filter%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Flatest_year%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20union%20%7B%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP1104%20%3Fpages%20.%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdate%20.%20%0A%20%20%20%20%20%20%20%20%3Fwork%20rdfs%3Alabel%20%3Flong_work_label%20.%20filter%28lang%28%3Flong_work_label%29%20%3D%20%27en%27%29%0A%20%20%20%20%20%20%20%20bind%28substr%28%3Flong_work_label%2C%201%2C%2020%29%20as%20%3Fwork_label%29%0A%20%20%20%20%20%20%20%20bind%28str%28year%28%3Fdate%29%29%20as%20%3Fyear%29%20%0A%20%20%20%20%20%20%7D%0A%09%7D%20%0A%09group%20by%20%3Fyear%20%3Fwork%20%3Fwork_label%0A%09order%20by%20%3Fyear%20%0A%20%20%7D%0A%7D"></iframe>
 </div>
 
 
-<h2 id="Venue statistics">Venue statistics</h2>
+<h2 id="venue-statistics">Venue statistics</h2>
 
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="venue-statistics-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Fvenue%20%28SAMPLE%28%3Fvenue_label_%29%20AS%20%3Fvenue_label%29%20%0AWITH%20%7B%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20as%20%3Fcount%29%20%3Fvenue%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP1433%20%3Fvenue%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fvenue%0A%7D%20AS%20%25counts%0AWHERE%20%7B%0A%20%20INCLUDE%20%25counts%0A%20%20%3Fvenue%20rdfs%3Alabel%20%3Flong_venue_label%20FILTER%28LANG%28%3Flong_venue_label%29%20%3D%20%27en%27%29%0A%20%20OPTIONAL%20%7B%20%3Fvenue%20wdt%3AP1813%20%3Fshort_name%20.%20%7D%0A%20%20BIND%28COALESCE%28%3Fshort_name%2C%20%3Flong_venue_label%29%20AS%20%3Fvenue_label_%29%0A%7D%0AGROUP%20BY%20%3Fvenue%20%3Fcount%0AORDER%20BY%20DESC%28%3Fcount%29%20%20"></iframe>
 </div>
 
-<table class="table table-hover" id="venue-statistics"></table>
+<table class="table table-hover" id="venue-statistics-table"></table>
 
 
-<h2 data-toogle="tooltip" title="Co-author graph for the author (up to 1000 links)">Co-author graph</h2>
+<h2 id="coauthor-graph" data-toogle="tooltip" title="Co-author graph for the author (up to 1000 links)">Co-author graph</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="coauthor-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0A%23%20Egocentric%20co-author%20graph%20for%20an%20author%0ASELECT%20%3Fauthor1%20%3Fauthor1Label%20%3Frgb%20%3Fauthor2%20%3Fauthor2Label%0AWITH%20%7B%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Fauthor1%20%3Fauthor2%20WHERE%20%7B%0A%20%20%20%20%23%20Find%20co-authors%0A%20%20%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%2C%20%3Fauthor1%2C%20%3Fauthor2%20.%0A%0A%20%20%20%20%23%20Filtering%20%0A%20%20%20%20%23%20Only%20journal%20and%20conference%20articles%2C%20books%2C%20not%20%28yet%3F%29%20software%0A%20%20%20%20%23%20VALUES%20%3Fpublication_type%20%7B%20wd%3AQ13442814%20wd%3AQ571%20wd%3AQ26973022%7D%20%20%0A%20%20%20%20%23%20%3Fwork%20wdt%3AP31%20%3Fpublication_type%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor1%20%3Fauthor2%0A%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%20%20%23%20Limit%20the%20size%20of%20the%20graph%2C%20to%20avoid%20overburdening%20the%20browser%0A%20%20LIMIT%201000%0A%7D%20AS%20%25authors%0AWITH%20%7B%0A%20%20SELECT%20%3Fauthor1%20%3Fauthor2%20%3Frgb%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25authors%0A%20%20%20%20%0A%20%20%20%20%23%20Exclude%20self-links%0A%20%20%20%20FILTER%20%28%3Fauthor1%20%21%3D%20%3Fauthor2%29%0A%20%20%20%20%0A%20%20%20%20%23%20Color%20according%20to%20gender%0A%20%20%20%20OPTIONAL%20%7B%0A%20%20%20%20%20%20%3Fauthor1%20wdt%3AP21%20%3Fgender1%20.%20%0A%20%20%20%20%20%20BIND%28%20IF%28%3Fgender1%20%3D%20wd%3AQ6581097%2C%20%223182BD%22%2C%20%22E6550D%22%29%20AS%20%3Frgb%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20%23%20Label%20the%20results%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cfr%2Cde%2Cru%2Ces%2Czh%2Cjp%22.%20%7D%0A%7D"></iframe>
 </div>
 
@@ -439,42 +439,42 @@ Are co-authors missing here? You can help curate them via the <a href="{{ url_fo
 <h2>Topics</h2>
 
 
-<h3>Topic scores</h3>
+<h3 id="topic-scores">Topic scores</h3>
 
 Topics based on a weighting between fields of work,
 topics of authored works and topics of citing works.  
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="topic-scores-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fscore%20%3Ftopic%20%3FtopicLabel%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%28SUM%28%3Fscore_%29%20AS%20%3Fscore%29%0A%20%20%20%20%3Ftopic%0A%20%20WHERE%20%7B%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP101%20%3Ftopic%20.%0A%20%20%20%20%20%20BIND%2820%20AS%20%3Fscore_%29%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%283%20AS%20%3Fscore_%29%20%3Ftopic%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20wdt%3AP921%20%3Ftopic%20.%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%281%20AS%20%3Fscore_%29%20%3Ftopic%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP921%20%3Ftopic%20.%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic%0A%7D%20AS%20%25results%20%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Cde%2Ces%2Cjp%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fscore%29%0ALIMIT%20200"></iframe>
 </div>
 
 
 
-<h3>Topics of authored works</h3>
+<h3 id="topics-of-authored-works">Topics of authored works</h3>
 
-<table class="table table-hover" id="topics"></table>
+<table class="table table-hover" id="topics-of-authored-works-table"></table>
 
 
-<h2>Associated images</h2>
+<h2 id="associated-images">Associated images</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="associated-images-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AImageGrid%0ASELECT%20DISTINCT%20%3Fimage%20WHERE%20%7B%0A%20%20%7B%0A%20%20%20%20%23%20Images%20of%20the%20person%0A%20%20%20%20wd%3A{{ q }}%20wdt%3AP18%20%3Fimage%20.%0A%20%20%7D%0A%20%20UNION%20%7B%0A%20%20%20%20%23%20Images%20from%20whatever%20property%20value%20is%20linked.%0A%20%20%20%20%0A%20%20%20%20%23%20Excluded%20%22different%20from%22%20property%20and%20take%20all%20other%20properties%0A%20%20%20%20wd%3A{{ q }}%20%21wdt%3AP1889%20%3Fitem%20.%0A%0A%20%20%20%20%3Fitem%20wdt%3AP18%20%3Fimage%20.%20%0A%20%20%20%20%0A%20%20%20%20%23%20All%20people%20are%20humans%2C%20so%20these%20images%20are%20excluded.%0A%20%20%20%20FILTER%20%28%3Fitem%20%21%3D%20wd%3AQ5%29%0A%20%20%7D%0A%20%20UNION%20%7B%0A%20%20%20%20%23%20Images%20associated%20with%20works%20of%20the%20author%2C%20both%20direct%20images%2C%0A%20%20%20%20%23%20images%20of%20topics%20of%20the%20works%20and%20images%20of%20coauthors.%0A%20%20%20%20wd%3A{{ q }}%20%5Ewdt%3AP50%20%2F%20%28wdt%3AP921%2a%20%7C%20wdt%3AP50%29%20%2F%20wdt%3AP18%20%3Fimage%20.%0A%20%20%7D%0A%7D%20%20%20"></iframe>
 </div>
 
 
-<h2 id="Topics-works matrix">Topics-works matrix</h2>
+<h2 id="topics-works-matrix">Topics-works matrix</h2>
 
-<div id="topics-works-matrix"></div>
+<div id="topics-works-matrix-graph"></div>
 
 <!-- <div class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ADimensions%0ASELECT%20%3Fcount%20%3Ftheme_label%20%3Fwork_label%20WHERE%20%7B%0A%20%20%7B%20%0A%20%20%20%20SELECT%20%3Ftheme%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20WHERE%20%7B%0A%20%20%09%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP921%20%3Ftheme%20.%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Ftheme%0A%20%20%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%20%20%7D%0A%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%3Fwork%20wdt%3AP921%20%3Ftheme%20.%0A%20%20%3Ftheme%20rdfs%3Alabel%20%3Ftheme_label%20.%20FILTER%20%28LANG%28%3Ftheme_label%29%20%3D%20%27en%27%29%0A%20%20%3Fwork%20rdfs%3Alabel%20%3Flong_work_label%20.%20FILTER%20%28LANG%28%3Flong_work_label%29%20%3D%20%27en%27%29%0A%20%20BIND%28SUBSTR%28%3Flong_work_label%2C%201%2C%2060%29%20AS%20%3Fwork_label%29%0A%7D%20"></iframe>
 </div -->
 
 
-<h2>Timeline</h2>
+<h2 id="author-timeline">Timeline</h2>
 
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="author-timeline-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ATimeline%0A%23%20Timeline%20for%20an%20author%0ASELECT%20%3Flabel%20%3Fbeginning%20%3Fending%20%3Feducation_degree_label%0AWITH%20%7B%0A%20%20SELECT%20%3Fwork%20%28MIN%28%3Fpublication_date%29%20AS%20%3Fbeginning%29%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fwork%0A%7D%20AS%20%25works_with_publication_date%0AWITH%20%7B%0A%20%20%0A%20%20SELECT%20%3Fwork%20%3Fbeginning%20%28COUNT%28%3Fciting_article%29%20AS%20%3Fnumber_of_citations%29%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works_with_publication_date%0A%20%20%20%20OPTIONAL%20%7B%20%3Fciting_article%20wdt%3AP2860%20%3Fwork%20.%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fwork%20%3Fbeginning%20%0A%7D%20AS%20%25works%0AWHERE%20%7B%0A%20%20%23%20%7B%20Birth%20wd%3A{{ q }}%20wdt%3AP569%20%3Fbeginning%20.%20BIND%28%22Birth%22%20AS%20%3Flabel%29%20%7D%20UNION%0A%20%20%7B%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20SELECT%20%3Fwork%20%3Fbeginning%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20ORDER%20BY%20DESC%28%3Fnumber_of_citations%29%0A%20%20%20%20%20%20LIMIT%201%20%20%20%20%20%20%20%20%0A%20%20%20%20%7D%0A%20%20%20%20BIND%28%22%F0%9F%93%96%20publication%20of%20most%20cited%20article%22%20AS%20%3Flabel%29%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20SELECT%20%3Fwork%20%3Fbeginning%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20ORDER%20BY%20%3Fbeginning%0A%20%20%20%20%20%20LIMIT%201%20%20%20%20%20%20%20%20%0A%20%20%20%20%7D%0A%20%20%20%20BIND%28%22%F0%9F%93%96%20first%20publication%22%20AS%20%3Flabel%29%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20SELECT%20%3Fwork%20%3Fbeginning%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20ORDER%20BY%20DESC%28%3Fbeginning%29%0A%20%20%20%20%20%20LIMIT%201%20%20%20%20%20%20%20%20%0A%20%20%20%20%7D%0A%20%20%20%20BIND%28%22%F0%9F%93%96%20latest%20publication%22%20AS%20%3Flabel%29%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20%23%20Education%0A%20%20%20%20wd%3A{{ q }}%20p%3AP69%20%3Feducation_statement%20.%0A%20%20%20%20%3Feducation_statement%20ps%3AP69%20%3Feducation%20.%0A%20%20%20%20%3Feducation%20rdfs%3Alabel%20%3Feducation_label%20.%20%0A%20%20%20%20FILTER%20%28lang%28%3Feducation_label%29%20%3D%20%27en%27%29%0A%20%20%20%20BIND%28CONCAT%28%22%F0%9F%A6%89%20%22%2C%20%3Feducation_label%29%20AS%20%3Flabel%29%0A%20%20%20%20OPTIONAL%20%7B%20%3Feducation_statement%20pq%3AP580%20%3Fbeginning%20.%20%7D%0A%20%20%20%20OPTIONAL%20%7B%20%3Feducation_statement%20pq%3AP582%20%3Fending%20.%20%7D%0A%20%20%20%20OPTIONAL%20%7B%0A%20%20%20%20%20%20%3Feducation_statement%20pq%3AP512%20%3Feducation_degree%20.%20%0A%20%20%20%20%20%20%3Feducation_degree%20rdfs%3Alabel%20%3Feducation_degree_label%20.%0A%20%20%20%20%20%20FILTER%20%28lang%28%3Feducation_degree_label%29%20%3D%20%27en%27%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20%23%20Affiliation%0A%20%20%20%20wd%3A{{ q }}%20p%3AP1416%20%7C%20p%3AP108%20%3Faffiliation_statement%20.%0A%20%20%20%20%3Faffiliation_statement%20ps%3AP1416%20%7C%20ps%3AP108%20%3Faffiliation%20.%0A%20%20%20%20%3Faffiliation%20rdfs%3Alabel%20%3Faffiliation_label%20.%0A%20%20%20%20FILTER%20%28lang%28%3Faffiliation_label%29%20%3D%20%27en%27%29%0A%20%20%20%20BIND%28CONCAT%28%22%F0%9F%8F%A0%20%22%2C%3Faffiliation_label%29%20AS%20%3Flabel%29%0A%20%20%20%20%23%20OPTIONAL%20%7B%20%3Faffiliation%20wdt%3AP18%20%3Fimage%20%7D%0A%20%20%20%20OPTIONAL%20%7B%20%3Faffiliation_statement%20pq%3AP580%20%3Fbeginning%20.%20%7D%0A%20%20%20%20OPTIONAL%20%7B%20%3Faffiliation_statement%20pq%3AP582%20%3Fending%20.%20%7D%0A%20%20%20%20OPTIONAL%20%7B%0A%20%20%20%20%20%20%3Faffiliation_statement%20pq%3AP512%20%3Faffiliation_degree%20.%20%0A%20%20%20%20%20%20%3Faffiliation_degree%20rdfs%3Alabel%20%3Faffiliation_degree_label%20.%0A%20%20%20%20%20%20FILTER%20%28lang%28%3Faffiliation_degree_label%29%20%3D%20%27en%27%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20wd%3A{{ q }}%20p%3AP166%20%3Faward_statement%20.%20%0A%20%20%20%20%3Faward_statement%20ps%3AP166%20%3Faward%20.%0A%20%20%20%20%3Faward%20rdfs%3Alabel%20%3Faward_label%20.%0A%20%20%20%20FILTER%20%28lang%28%3Faward_label%29%20%3D%20%27en%27%29%0A%20%20%20%20BIND%28CONCAT%28%22%F0%9F%8F%86%20%22%2C%3Faward_label%29%20AS%20%3Flabel%29%0A%20%20%20%20%3Faward_statement%20pq%3AP585%20%3Fbeginning%20.%0A%20%20%7D%0A%0A%7D%20"></iframe>
 </div>
 
@@ -493,49 +493,49 @@ topics of authored works and topics of citing works.
 </div -->
 
 
-<h2 id="Academic tree">Academic tree</h2>
+<h2 id="academic-tree">Academic tree</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="academic-tree-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0A%23%20Doctoral%20student%2Fadvisor%20network%20with%20a%20source%20from%20a%20spectific%20researcher%0APREFIX%20gas%3A%20%3Chttp%3A%2F%2Fwww.bigdata.com%2Frdf%2Fgas%23%3E%0A%0ASELECT%20DISTINCT%20%3Fstudent1%20%3Fstudent1Label%20%3Fsupervisor1%20%3Fsupervisor1Label%0AWHERE%20%7B%0A%20%20%7B%20%0A%20%20%20%20SELECT%20%3Fstudent1%20%3Fsupervisor1%20%28MIN%28%3Fdepth1%29%20as%20%3Fdepth%29%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20SERVICE%20gas%3Aservice%20%7B%0A%20%20%20%20%20%20%20%20gas%3Aprogram%20gas%3AgasClass%20%22com.bigdata.rdf.graph.analytics.BFS%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Ain%20wd%3A{{ q }}%20%3B%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AtraversalDirection%20%22Forward%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout%20%3Fstudent1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout1%20%3Fdepth1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout2%20%3Fsupervisor1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AlinkType%20wdt%3AP185%20%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fstudent1%20%3Fsupervisor1%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%20%0A%20%20%20%20SELECT%20%3Fstudent1%20%3Fsupervisor1%20%28MIN%28%3Fdepth1%29%20as%20%3Fdepth%29%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20service%20gas%3Aservice%20%7B%0A%20%20%20%20%20%20%20%20gas%3Aprogram%20gas%3AgasClass%20%22com.bigdata.rdf.graph.analytics.BFS%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Ain%20wd%3A{{ q }}%20%3B%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AtraversalDirection%20%22Forward%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout%20%3Fsupervisor1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout1%20%3Fdepth1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout2%20%3Fstudent1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AlinkType%20wdt%3AP184%20%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fstudent1%20%3Fsupervisor1%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%20%0A%20%20%20%20SELECT%20%3Fstudent1%20%3Fsupervisor1%20%28MIN%28%3Fdepth1%29%20as%20%3Fdepth%29%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20SERVICE%20gas%3Aservice%20%7B%0A%20%20%20%20%20%20%20%20gas%3Aprogram%20gas%3AgasClass%20%22com.bigdata.rdf.graph.analytics.BFS%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Ain%20wd%3A{{ q }}%20%3B%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AtraversalDirection%20%22Reverse%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout%20%3Fstudent1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout1%20%3Fdepth1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout2%20%3Fsupervisor1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AlinkType%20wdt%3AP184%20%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fstudent1%20%3Fsupervisor1%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%20%0A%20%20%20%20SELECT%20%3Fstudent1%20%3Fsupervisor1%20%28MIN%28%3Fdepth1%29%20as%20%3Fdepth%29%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20SERVICE%20gas%3Aservice%20%7B%0A%20%20%20%20%20%20%20%20gas%3Aprogram%20gas%3AgasClass%20%22com.bigdata.rdf.graph.analytics.BFS%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Ain%20wd%3A{{ q }}%20%3B%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AtraversalDirection%20%22Reverse%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout%20%3Fsupervisor1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout1%20%3Fdepth1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout2%20%3Fstudent1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AlinkType%20wdt%3AP185%20%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fstudent1%20%3Fsupervisor1%0A%20%20%7D%0A%20%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Csv%2Cjp%2Czh%2Cru%2Cfr%2Cde%22%20.%20%20%7D%20%0A%7D%0A"></iframe>
 </div>
 
 
-<h2 id="Locations">Locations</h2>
+<h2 id="author-locations">Locations</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="author-locations-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%0ASELECT%20DISTINCT%20%3Fimage%20%3Fitem%20%3FitemLabel%20%3Fgeo%20%28%3Fproperty_item_label%20AS%20%3Flayer%29%0AWHERE%20%7B%0A%20%20wd%3A{{ q }}%20%3Fproperty%20%3Fitem%20.%20%0A%20%20%3Fitem%20p%3AP159%2Fpq%3AP625%20%7C%20wdt%3AP276%2a%2Fwdt%3AP625%20%3Fgeo%20.%0A%20%20%3Fproperty_item%20wikibase%3AdirectClaim%20%3Fproperty%20.%0A%20%20OPTIONAL%20%7B%20%3Fitem%20wdt%3AP18%20%3Fimage%20.%20%7D%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%20%20%0A%20%20%23%20No%20automatic%20labeling%20on%20the%20property%2C%20-%20for%20some%20reason.%0A%20%20%3Fproperty_item%20rdfs%3Alabel%20%3Fproperty_item_label%20.%20FILTER%28LANG%28%3Fproperty_item_label%29%20%3D%20%27en%27%29%0A%7D%20%20"></iframe>
 </div>
 
 
-<h2>Citation statistics</h2>
+<h2 id="citation-statistics">Citation statistics</h2>
 
 <h3>Most cited works</h3>
 
 Works of the author ordered according to number of citations received.
 
-<table class="table table-hover" id="most-cited-works"></table>
+<table class="table table-hover" id="citation-statistics-table"></table>
 
 
-<h3 id="Citations by year">Citations by year</h3>
+<h3 id="citations-by-year">Citations by year</h3>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="citations-by-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%20%3Fyear%20%28count%28distinct%20%3Fciting_work%29%20as%20%3Fcount%29%20%3Fkind%20%20WHERE%20%7B%0A%20%20%3Fwork%20wdt%3AP50%20wd%3A{{ q }}%20.%0A%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%0A%20%20bind%28if%20%28exists%20%7B%20%3Fciting_work%20wdt%3AP50%20wd%3A{{ q }}%20%7D%2C%20%22self-citations%22%2C%20%22citations%20from%20others%22%29%20as%20%3Fkind%29%0A%20%20%3Fciting_work%20wdt%3AP577%20%3Fdate%20.%0A%20%20BIND%28str%28YEAR%28%3Fdate%29%29%20AS%20%3Fyear%29%0A%7D%20group%20by%20%3Fyear%20%3Fkind%0Aorder%20by%20desc%28%3Fyear%29%20%20%20%20"></iframe>
 </div>
 
 
-<h3>Citing authors</h3>
+<h3 id="citing-authors">Citing authors</h3>
 
 Authors that cite the author (excluding self citations).
 
-<table class="table table-hover" id="citing-authors"></table>
+<table class="table table-hover" id="citing-authors-table"></table>
 
 Are citing authors missing here? You can help curate them via the <a href="{{ url_for('app.show_author_empty') }}{{ q }}/missing">missing</a> page.
 
 
-<h2>Events</h2>
+<h2 id="author-events">Events</h2>
 
 Conferences, workshops and other events the author has attended or otherwise been associated with.
 
-<table class="table table-hover table-striped" id="events"></table>
+<table class="table table-hover table-striped" id="author-events-table"></table>
 
 {% endblock %}

--- a/scholia/app/templates/author_missing.html
+++ b/scholia/app/templates/author_missing.html
@@ -155,42 +155,42 @@ ORDER BY DESC(?citations)
 
 {% block page_content %}
 
-<h1 id="h1">Author</h1>
+<h1 id="author-intro">Author</h1>
 
 Missing information with respect to the author.
 
 
-<h2>Author name strings to be resolved</h2>
+<h2 id="author-name-strings-need-resolve">Author name strings to be resolved</h2>
 
 The authorship may be represented as an author name string rather than a Wikidata item.
 To try to resolve the author name strings, follow the links below to use the Author disambiguator tool, which also has a <a href="https://author-disambiguator.toolforge.org/author_item_oauth.php?id={{ q }}">dedicated page for this author</a>.
 
-<table class="table table-hover" id="missing-author-resolving"></table>
+<table class="table table-hover" id="author-name-strings-need-resolve-table"></table>
 
 
-<h2>Missing coauthor items</h2>
+<h2 id="missing-coauthor-items">Missing coauthor items</h2>
 
 The coauthors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
 Follow the link to use the Author disambiguator tool to try to resolve
 the authors.
 
-<table class="table table-hover" id="missing-coauthor-items"></table>
+<table class="table table-hover" id="missing-coauthor-items-table"></table>
 
 
-<h2>Missing citing author items</h2>
+<h2 id="missing-citing-author-items">Missing citing author items</h2>
 
 The citing authors below are only represented as strings in Wikidata and not linked to
 Wikidata items.
 Follow the link to use the Author disambiguator tool to try to resolve
 the authors.
 
-<table class="table table-hover" id="missing-citing-author-items"></table>
+<table class="table table-hover" id="missing-citing-author-items-table"></table>
 
 
-<h2>Authored works with missing topics</h2>
+<h2 id="missing-works-topics">Authored works with missing topics</h2>
 
-<table class="table table-hover" id="missing-topic"></table>
+<table class="table table-hover" id="missing-works-topics-table"></table>
 
 
 

--- a/scholia/app/templates/authors.html
+++ b/scholia/app/templates/authors.html
@@ -52,36 +52,35 @@ ORDER BY DESC(?coauthor_count)
 
 {% block page_content %}
 
-<h1 id="h1">Authors</h1>
+<h1 id="authors">Authors</h1>
 
-<div id="intro"></div>
-
-
-<table class="table table-hover" id="list-of-authors"></table>
+<div id="authors-intro"></div>
 
 
-<h2>List of jointly authored works</h2>
+<table class="table table-hover" id="authors-table"></table>
 
-<table class="table table-hover" id="list-of-jointly-authored-works"></table>
 
-<h2>Number of works per publication year</h2>
+<h2 id="list-jointly-authored-works">List of jointly authored works</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<table class="table table-hover" id="list-jointly-authored-works-table"></table>
+
+<h2 id="works-per-publication-per-year">Number of works per publication year</h2>
+
+<div id="works-per-publication-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%20%3Fyear%20%3Fnumber_of_works%20%3Fauthor_label%20WHERE%20%7B%0A%20%20%7B%0A%20%20%20%20SELECT%20%3Fyear%20%3Fnumber_of_works%20%3Fauthor%20%3Fauthor_label_%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20SELECT%20%3Fauthor%20%3Fyear%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_works%29%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%20%20hint%3AQuery%20hint%3Aoptimizer%20%22None%22.%0A%20%20%20%20%20%20%20%20%20%20VALUES%20%3Fauthor%20%7B%20%20%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%0A%20%20%20%20%20%20%20%20%20%20BIND%28STR%28YEAR%28%3Fpublication_date%29%29%20AS%20%3Fyear%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20GROUP%20BY%20%3Fauthor%20%3Fyear%20%0A%20%20%20%20%20%20%7D%20%0A%20%20%20%20%20%20%3Fauthor%20rdfs%3Alabel%20%3Fauthor_label_%20.%0A%20%20%20%20%20%20FILTER%20%28LANG%28%3Fauthor_label_%29%20%3D%20%27en%27%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%23%20Represent%20the%20author%20by%20name%20and%20Q%20identifier%0A%20%20BIND%20%28CONCAT%28%3Fauthor_label_%2C%20%22%20%28%22%2C%20SUBSTR%28STR%28%3Fauthor%29%2C%2032%29%2C%20%22%29%22%29%20AS%20%3Fauthor_label%29%0A%7D%0AORDER%20BY%20%3Fyear"></iframe>
 </div>
 
 
+<h2 id="citations-per-publication-per-year">Number of citations per publication year</h2>
 
-<h2>Number of citations per publication year</h2>
-
-<div class="embed-responsive embed-responsive-16by9">
+<div id="citations-per-publication-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%20%3Fyear%20%3Fnumber_of_citations%20%3Fauthor_label%20WHERE%20%7B%0A%20%20%7B%0A%20%20%20%20SELECT%20%3Fyear%20%3Fnumber_of_citations%20%3Fauthor%20%3Fauthor_label_%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20SELECT%20%3Fauthor%20%3Fyear%20%28COUNT%28%3Fciting_work%29%20AS%20%3Fnumber_of_citations%29%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%20%20hint%3AQuery%20hint%3Aoptimizer%20%22None%22.%0A%20%20%20%20%20%20%20%20%20%20VALUES%20%3Fauthor%20%7B%20%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%0A%20%20%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%0A%20%20%20%20%20%20%20%20%20%20BIND%28STR%28YEAR%28%3Fpublication_date%29%29%20AS%20%3Fyear%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20GROUP%20BY%20%3Fauthor%20%3Fyear%20%0A%20%20%20%20%20%20%7D%20%0A%20%20%20%20%20%20%3Fauthor%20rdfs%3Alabel%20%3Fauthor_label_%20.%0A%20%20%20%20%20%20FILTER%20%28LANG%28%3Fauthor_label_%29%20%3D%20%27en%27%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%23%20Represent%20the%20author%20by%20name%20and%20Q%20identifier%0A%20%20BIND%20%28CONCAT%28%3Fauthor_label_%2C%20%22%20%28%22%2C%20SUBSTR%28STR%28%3Fauthor%29%2C%2032%29%2C%20%22%29%22%29%20AS%20%3Fauthor_label%29%0A%7D%0AORDER%20BY%20%3Fyear"></iframe>
 </div>
 
 
-<h2 id="Co-author graph">Co-author graph</h2>
+<h2 id="co-author-graph">Co-author graph</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="co-author-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0APREFIX%20gas%3A%20%3Chttp%3A%2F%2Fwww.bigdata.com%2Frdf%2Fgas%23%3E%0A%0ASELECT%20%3Fauthor%20%3FauthorLabel%20%3Fwork%20%3FworkLabel%20%0AWITH%20%7B%0A%20SELECT%20%3Fwork%20%3Fauthor%20WHERE%20%7B%20%0A%20%20%7B%20%7D%0A%20%20{% for q1 in qs %} {% for q2 in qs %} {% if q1 < q2 %} UNION%20%7B%0A%20%20%20SELECT%20%3Fwork%20%3Fauthor%20WHERE%20%7B%0A%20%20%20%20SERVICE%20gas%3Aservice%20%7B%0A%20%20%20%20%20gas%3Aprogram%20gas%3AgasClass%20%22com.bigdata.rdf.graph.analytics.BFS%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3Ain%20wd:{{ q1 }}%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3Atarget%20wd:{{ q2 }}%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3AtraversalDirection%20%22Undirected%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3Aout%20%3Fwork%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20gas%3AlinkType%20wdt%3AP50%20%3B%0A%20%20%20%20%20%20%20%20%20%20gas%3AmaxVisited%205000%20.%0A%20%20%20%20%7D%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%0A%20%20%20%7D%0A%20%20%7D%20%23%20UNION%20END%0A  {% endif %} {% endfor %}  {% endfor %} %20%7D%20%0A%7D%20AS%20%25result%20%0AWHERE%20%7B%0A%20INCLUDE%20%25result%20%0A%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Che%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%20"></iframe>
 </div>
 

--- a/scholia/app/templates/award.html
+++ b/scholia/app/templates/award.html
@@ -107,47 +107,47 @@ WHERE {
 
 
 
-<h1 id="h1">Award</h1>
+<h1 id="award">Award</h1>
 
-<div id="intro"></div>
+<div id="award-intro"></div>
 
-<div id="wembedder"></div>
-
-
-<h2 id="List-of-recipients">List of recipients</h2>
-
-<table class="table table-hover" id="list-of-recipients"></table>
+<div id="award-wembedder"></div>
 
 
-<h2 id="Images-of-recipients">Images of recipients</h2>
+<h2 id="list-of-recipients">List of recipients</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<table class="table table-hover" id="list-of-recipients-table"></table>
+
+
+<h2 id="images-of-recipients">Images of recipients</h2>
+
+<div id="images-of-recipients-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AImageGrid%0ASELECT%0A%20%20%3Fyear%0A%20%20%3Frecipient%20%3FrecipientLabel%20%0A%20%20%3Fimage%0AWITH%20%7B%0A%20%20SELECT%20%3Frecipient%20%3Fyear%20%28SAMPLE%28%3Fimage_%29%20AS%20%3Fimage%29%20WHERE%20%7B%0A%20%20%20%20%3Frecipient%20p%3AP166%20%3Faward_statement%20.%20%0A%20%20%20%20%3Faward_statement%20ps%3AP166%20wd%3A{{ q }}%20.%0A%20%20%20%20OPTIONAL%20%7B%0A%20%20%20%20%20%20%3Faward_statement%20pq%3AP585%20%3Ftime%20.%0A%09%20%20BIND%28YEAR%28%3Ftime%29%20AS%20%3Fyear%29%0A%09%7D%0A%20%20%20%20%3Frecipient%20wdt%3AP18%20%3Fimage_%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Frecipient%20%3Fyear%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%20%20%0A%7D%0AORDER%20BY%20DESC%28%3Fyear%29%0A%20%20"></iframe>
 </div>
 
 
-<h2 id="Topics-of-works-by-recipients">Topics of works by recipients</h2>
+<h2 id="topics-of-works-by-recipients">Topics of works by recipients</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="topics-of-works-by-recipients-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0A%23%20Count%20the%20number%20of%20time%20works%20by%20award%20recipients%20have%20set%20a%20main%20topic%0ASELECT%20%3Fcount%20%3Ftopic%20%3FtopicLabel%20%0AWITH%20%7B%0A%20%20SELECT%20%3Ftopic%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20WHERE%20%7B%0A%20%20%20%20%3Frecipient%20wdt%3AP166%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Frecipient%20.%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Ftopic%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%20%20%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0ALIMIT%2050"></iframe>
 </div>
 
 
-<h2 id="Recent-publications-by-recipients">Recent publications by recipients</h2>
+<h2 id="recent-publications-by-recipients">Recent publications by recipients</h2>
 
-<table class="table table-hover" id="recent-publications-by-recipients"></table>
+<table class="table table-hover" id="recent-publications-by-recipients-table"></table>
 
 
-<h2 id="Co-awards">Co-awards</h2>
+<h2 id="co-awards">Co-awards</h2>
 
 Awards with co-recipients 
 
-<table class="table table-hover" id="co-awards"></table>
+<table class="table table-hover" id="co-awards-table"></table>
 
 
-<h2 id="Locations-of-recipients">Locations of recipients</h2>
+<h2 id="locations-of-recipients">Locations of recipients</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="locations-of-recipients-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%0ASELECT%20DISTINCT%20%3Frecipient%20%3FrecipientLabel%20%3Fimage%20%3Fitem%20%3FitemLabel%20%3Fgeo%20%3Flayer%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Frecipient%20%3Fimage%20%3Fitem%20%3Fgeo%20%28%3Fproperty_item_label%20AS%20%3Flayer%29%20WHERE%20%7B%0A%20%20%20%20%3Frecipient%20wdt%3AP166%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Frecipient%20%3Fproperty%20%3Fitem%20.%20%0A%20%20%20%20%3Fitem%20wdt%3AP625%20%3Fgeo%20.%0A%20%20%20%20%3Fproperty_item%20wikibase%3AdirectClaim%20%3Fproperty%20.%0A%20%20%20%20%3Fproperty_item%20rdfs%3Alabel%20%3Fproperty_item_label%20.%20FILTER%20%28LANG%28%3Fproperty_item_label%29%20%3D%20%27en%27%29%0A%20%20%20%20OPTIONAL%20%7B%20%3Fitem%20wdt%3AP18%20%3Fimage%20.%20%7D%0A%20%20%7D%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%20%0A%7D"></iframe>
 </div>
 

--- a/scholia/app/templates/award.html
+++ b/scholia/app/templates/award.html
@@ -111,7 +111,7 @@ WHERE {
 
 <div id="award-intro"></div>
 
-<div id="award-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 id="list-of-recipients">List of recipients</h2>

--- a/scholia/app/templates/award_empty.html
+++ b/scholia/app/templates/award_empty.html
@@ -24,9 +24,9 @@ Awards, prizes.
 
 <h2>Aggregates</h2>
 
-<h3>Male-female statistics</h3>
+<h3 id="male-female-statistics">Male-female statistics</h3>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="male-female-statistics-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AScatterChart%0A%23%20Statistics%20on%20number%20of%20recipients%20for%20award%20wrt.%20gender%0ASELECT%20%3Fmales%20%3Ffemales%20%3Faward%20%3FawardLabel%20%0AWITH%20%7B%0A%20%20SELECT%20%28COUNT%28%3Frecipient_male%29%20AS%20%3Fmales%29%20%28COUNT%28%3Frecipient_female%29%20AS%20%3Ffemales%29%20%3Faward%20WHERE%20%7B%0A%20%20%20%20%3Faward%20wdt%3AP31%20wd%3AQ11448906%20.%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20%3Frecipient_male%20wdt%3AP166%20%3Faward%20.%0A%20%20%20%20%20%20%3Frecipient_male%20wdt%3AP21%20wd%3AQ6581097%20.%0A%20%20%20%20%7D%0A%20%20%20%20UNION%20%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%3Frecipient_female%20wdt%3AP166%20%3Faward%20.%0A%20%20%20%20%20%20%3Frecipient_female%20wdt%3AP21%20wd%3AQ6581072%20.%0A%20%20%20%20%7D%20%20%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Faward%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%20%0AORDER%20BY%20DESC%28%3Fmales%29%20DESC%28%3Ffemale%29%20"></iframe>
 </div>
 

--- a/scholia/app/templates/award_missing.html
+++ b/scholia/app/templates/award_missing.html
@@ -113,36 +113,36 @@ ORDER BY DESC(?citations)
 
 {% block page_content %}
 
-<h1 id="h1">Award</h1>
+<h1 id="award">Award</h1>
 
 Missing information with respect to the award.
 
 
 
-  <h2>Missing author items</h2>
+  <h2 id="missing-author-items">Missing author items</h2>
 
 The authors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
 Follow the link to use the Author disambiguator tool to try to resolve
 the authors.
 
-<table class="table table-hover" id="missing-author-items"></table>
+<table class="table table-hover" id="missing-author-items-table"></table>
 
 
-  <h2>Missing coauthor items</h2>
+  <h2 id="missing-coauthor-items">Missing coauthor items</h2>
 
 The coauthors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
 Follow the link to use the Author disambiguator tool to try to resolve
 the authors.
 
-<table class="table table-hover" id="missing-coauthor-items"></table>
+<table class="table table-hover" id="missing-coauthor-items-table"></table>
 
-  <h2>Missing topics</h2>
+  <h2 id="missing-topics">Missing topics</h2>
 
 The works listed below do not currently have statements about their main subjects.
 
-<table class="table table-hover" id="missing-topics"></table>
+<table class="table table-hover" id="missing-topics-table"></table>
 
 
 

--- a/scholia/app/templates/catalogue.html
+++ b/scholia/app/templates/catalogue.html
@@ -40,19 +40,19 @@ LIMIT 1000
 
 {% block page_content %}
 
-<h1 id="h1">Catalogue</h1>
+<h1 id="catalouge">Catalogue</h1>
 
-<div id="intro"></div>
-
-
-<h2>Items in catalogue</h2>
-
-<table class="table table-hover" id="items-in-catalogue"></table>
+<div id="catalouge-intro"></div>
 
 
-<h2>Images</h2>
+<h2 id="items-in-catalogue">Items in catalogue</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<table class="table table-hover" id="items-in-catalogue-table"></table>
+
+
+<h2 id="catalogue-images">Images</h2>
+
+<div id="catalogue-images-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AImageGrid%0ASELECT%0A%20%20%3Fimage%0A%20%20%3Fitem%20%3FitemLabel%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP972%20wd%3A{{ q }}%20%3B%0A%20%20%20%20%20%20%20%20wdt%3AP18%20%3Fimage%20.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -207,7 +207,7 @@ LIMIT 500
 
 <div id="chemical-intro"></div>
 
-<div id="chemical-wembedder"></div>
+<div id="wembedder"></div>
 
 {% endif %}
 

--- a/scholia/app/templates/chemical.html
+++ b/scholia/app/templates/chemical.html
@@ -184,7 +184,7 @@ LIMIT 500
 
 
 {% block page_content %}
-<h1 id="h1">Chemical</h1>
+<h1 id="chemical">Chemical</h1>
 <script type="application/ld+json" id="bioschemas"></script>
 
 {% if third_parties_enabled %}
@@ -205,35 +205,35 @@ LIMIT 500
 
 {% else %}
 
-<div id="intro"></div>
+<div id="chemical-intro"></div>
 
-<div id="wembedder"></div>
+<div id="chemical-wembedder"></div>
 
 {% endif %}
 
-<h2 id="StructuralInformation">Structural Information</h2>
+<h2 id="chemical-structural-information">Structural Information</h2>
 
-<table class="table table-hover" id="structures"></table>
+<table class="table table-hover" id="chemical-structural-information-table"></table>
 
-<h2 id="Identifiers">Identifiers</h2>
+<h2 id="chemical-identifiers">Identifiers</h2>
 
-<table class="table table-hover" id="identifiers"></table>
+<table class="table table-hover" id="chemical-identifiers-table"></table>
 
-<h2 id="Related">Related Compounds</h2>
+<h2 id="chemical-related-compounds">Related Compounds</h2>
 
-<table class="table table-hover" id="related"></table>
+<table class="table table-hover" id="chemical-related-compounds-table"></table>
 
-<h2 id="PhysChem">Physchem Properties</h2>
+<h2 id="chemical-physchem-properties">Physchem Properties</h2>
 
-<table class="table table-hover" id="properties"></table>
+<table class="table table-hover" id="chemical-physchem-properties-table"></table>
 
-<h2 id="Recently published works on the chemical">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="chemical-recent-articles">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<table class="table table-hover" id="recentArticles"></table>
+<table class="table table-hover" id="chemical-recent-articles-table"></table>
 
-<h2 id="Publications per year">Publications per year</h2>
+<h2 id="chemical-publications-per-year">Publications per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="chemical-publications-per-year-iframe" class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item"  src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0A%23%20Inspired%20from%20LEGOLAS%20-%20http%3A%2F%2Fabel.lis.illinois.edu%2Flegolas%2F%0A%23%20Shubhanshu%20Mishra%2C%20Vetle%20Torvik%0Aselect%20%3Fyear%20%28count%28%3Fwork%29%20as%20%3Fnumber_of_publications%29%20where%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%28str%28%3Fyear_%29%20as%20%3Fyear%29%20%280%20as%20%3Fpages%29%20where%20%7B%0A%20%20%20%20%20%20%23%20default%20values%20%3D%200%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20%20%20bind%28year%28%3Fdate%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20select%20%28min%28%3Fyear_%29%20as%20%3Fearliest_year%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2F%28%5Ewdt%3AP361%29%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20wd%3A{{ q }}%20%3Fpropp%20%3Fstatement%20.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Fstatement%20a%20wikibase%3ABestRank%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20prov%3AwasDerivedFrom%2Fpr%3AP248%20%3Fwork%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fpublication_date%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20bind%28year%28now%28%29%29%20as%20%3Fnext_year%29%0A%20%20%20%20%20%20filter%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Fnext_year%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20union%20%7B%0A%20%20%20%20select%20%3Fwork%20%28min%28%3Fyears%29%20as%20%3Fyear%29%20where%20%7B%0A%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP527%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20wd%3A{{ q }}%20%3Fpropp%20%3Fstatement%20.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Fstatement%20a%20wikibase%3ABestRank%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20prov%3AwasDerivedFrom%2Fpr%3AP248%20%3Fwork%20.%20%7D%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdates%20.%0A%20%20%20%20%20%20bind%28str%28year%28%3Fdates%29%29%20as%20%3Fyears%29%20.%0A%20%20%20%20%7D%0A%20%20%20%20group%20by%20%3Fwork%20%0A%20%20%7D%0A%7D%0Agroup%20by%20%3Fyear%20%0Aorder%20by%20%3Fyear" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
 </div>
 {% endblock %}

--- a/scholia/app/templates/chemical_class.html
+++ b/scholia/app/templates/chemical_class.html
@@ -125,28 +125,28 @@ LIMIT 500
 
 <div id="intro"></div>
 
-<h2 id="ClassHierarchy">Class Hierarchy</h2>
+<h2 id="class-hierarchy">Class Hierarchy</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="class-hierarchy-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%20%3Fclass%20%3FclassLabel%20%3Fotherclass%20%3FotherclassLabel%20%3Frgb%20WITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fclass%20%3Fotherclass%20%3Frgb%20WHERE%20%7B%0A%20%20%20%20%7B%20VALUES%20%3Fclass%20%7B%20wd%3A{{ q }}%20%7D%0A%20%20%20%20%20%20%7B%20%3Fotherclass%20wdt%3AP279%20%3Fclass%20.%20BIND%28%20%223182BD%22%20AS%20%3Frgb%29%20%7D%0A%20%20%20%20%20%20UNION%0A%20%20%20%20%20%20%7B%20%3Fotherclass%20wdt%3AP31%20%3Fclass%20.%20BIND%28%20%22E6550D%22%20AS%20%3Frgb%29%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%20VALUES%20%3Fotherclass%20%7B%20wd%3A{{ q }}%20%7D%0A%20%20%20%20%20%20%3Fotherclass%20wdt%3AP279%20%3Fclass%20.%0A%20%20%20%20%7D%0A%20%20%7D%20LIMIT%20500%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%7D%0A"></iframe>
 </div>
 
-<h2 id="Identifiers">Identifiers</h2>
+<h2 id="class-dentifiers">Identifiers</h2>
 
-<table class="table table-hover" id="identifiers"></table>
+<table class="table table-hover" id="class-dentifiers-table"></table>
 
-<h2 id="Related">Example Compounds</h2>
+<h2 id="example-compounds">Example Compounds</h2>
 
-<table class="table table-hover" id="related"></table>
+<table class="table table-hover" id="example-compounds-table"></table>
 
 
-<h2 id="Recently published works on the chemical">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recent-articles">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<table class="table table-hover" id="recentArticles"></table>
+<table class="table table-hover" id="recent-article-table"></table>
 
-<h2 id="Publications per year">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="publications-per-year-iframe" class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item"  src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0A%23%20Inspired%20from%20LEGOLAS%20-%20http%3A%2F%2Fabel.lis.illinois.edu%2Flegolas%2F%0A%23%20Shubhanshu%20Mishra%2C%20Vetle%20Torvik%0Aselect%20%3Fyear%20%28count%28%3Fwork%29%20as%20%3Fnumber_of_publications%29%20where%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%28str%28%3Fyear_%29%20as%20%3Fyear%29%20%280%20as%20%3Fpages%29%20where%20%7B%0A%20%20%20%20%20%20%23%20default%20values%20%3D%200%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20%20%20bind%28year%28%3Fdate%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20select%20%28min%28%3Fyear_%29%20as%20%3Fearliest_year%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP361%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20wd%3A{{ q }}%20%3Fpropp%20%3Fstatement%20.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Fstatement%20a%20wikibase%3ABestRank%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20prov%3AwasDerivedFrom%2Fpr%3AP248%20%3Fwork%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fpublication_date%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20bind%28year%28now%28%29%29%20as%20%3Fnext_year%29%0A%20%20%20%20%20%20filter%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Fnext_year%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20union%20%7B%0A%20%20%20%20select%20%3Fwork%20%28min%28%3Fyears%29%20as%20%3Fyear%29%20where%20%7B%0A%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP361%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20wd%3A{{ q }}%20%3Fpropp%20%3Fstatement%20.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Fstatement%20a%20wikibase%3ABestRank%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20prov%3AwasDerivedFrom%2Fpr%3AP248%20%3Fwork%20.%20%7D%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdates%20.%0A%20%20%20%20%20%20bind%28str%28year%28%3Fdates%29%29%20as%20%3Fyears%29%20.%0A%20%20%20%20%7D%0A%20%20%20%20group%20by%20%3Fwork%20%0A%20%20%7D%0A%7D%0Agroup%20by%20%3Fyear%20%0Aorder%20by%20%3Fyear" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
 </div>
 

--- a/scholia/app/templates/chemical_element.html
+++ b/scholia/app/templates/chemical_element.html
@@ -92,23 +92,23 @@ LIMIT 500
 
 
 {% block page_content %}
-<h1 id="h1">Chemical</h1>
+<h1 id="chemical">Chemical</h1>
 
-<div id="intro"></div>
+<div id="chemical-intro"></div>
 
-<div id="wembedder"></div>
+<div id="chemical-wembedder"></div>
 
-<h2 id="Isotopes">Isotopes</h2>
+<h2 id="chemical-isotopes">Isotopes</h2>
 
-<table class="table table-hover" id="isotopes"></table>
+<table class="table table-hover" id="chemical-isotopes-table"></table>
 
-<h2 id="Isotopes">Allotropes</h2>
+<h2 id="chemical-allotropes">Allotropes</h2>
 
-<table class="table table-hover" id="allotropes"></table>
+<table class="table table-hover" id="chemical-allotropes-table"></table>
 
-<h2 id="Recently published works on the chemical">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="chemical-recent-articles">Recently published works on the chemical <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<table class="table table-hover" id="recentArticles"></table>
+<table class="table table-hover" id="chemical-recent-articles-table"></table>
 
 {% endblock %}
     

--- a/scholia/app/templates/chemical_element.html
+++ b/scholia/app/templates/chemical_element.html
@@ -96,7 +96,7 @@ LIMIT 500
 
 <div id="chemical-intro"></div>
 
-<div id="chemical-wembedder"></div>
+<div id="wembedder"></div>
 
 <h2 id="chemical-isotopes">Isotopes</h2>
 

--- a/scholia/app/templates/chemical_empty.html
+++ b/scholia/app/templates/chemical_empty.html
@@ -97,9 +97,9 @@ Chemical substances.
 </div>
 
 <div class="container">
-  <h2>Statistics</h2>
+  <h2 id="statistics-table">Statistics</h2>
 
-  <table class="table table-hover" id="statistics"></table>
+  <table class="table table-hover" id="statistics-table"></table>
 
 </div>
 

--- a/scholia/app/templates/chemicals_missing.html
+++ b/scholia/app/templates/chemicals_missing.html
@@ -246,7 +246,7 @@ The following links prioritize chemical compounds that are listed in most Wikis
 (Wikipedias, Wikimedia Commons, etc). To go to the Wikidata page for each item, click its name
 below, which will lead to its Scholia page which links to the Wikidata page via the <a href="https://www.wikidata.org/wiki/Wikidata:Glossary">Q number</a> link at the top.
 
-<h2 id="h1">Missing Boiling Points</h2>
+<h2 id="missing-boiling-points">Missing Boiling Points</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2102">boiling point</a> is the temperature
 at which boiling occurs under a pressure of one bar.
@@ -256,9 +256,9 @@ Typical units given include degrees
 it depends on the pressure, this is often also given, as shown in
 <a href="https://www.wikidata.org/wiki/Property:P2102#P1855">these examples</a>.
 
-<table class="table table-hover" id="missing-boiling-points"></table>
+<table class="table table-hover" id="missing-boiling-points-table"></table>
 
-<h2 id="h1">Missing Melting Points</h2>
+<h2 id="missing-melting-points">Missing Melting Points</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2101">melting point</a> is the temperature at which a compound melts. Typical units given include degrees
 <a href="{{ url_for('app.show_topic_empty') }}Q11579">Kelvin</a> and degrees
@@ -266,61 +266,61 @@ The <a href="https://www.wikidata.org/wiki/Property:P2101">melting point</a> is 
 often found for organic chemicals as part of their unique characterization. Check out
 <a href="https://www.wikidata.org/wiki/Property:P2101#P1855">these examples</a>.
 
-<table class="table table-hover" id="missing-melting-points"></table>
+<table class="table table-hover" id="missing-melting-points-table"></table>
 
-<h2 id="h1">Missing Mass</h2>
+<h2 id="missing-mass">Missing Mass</h2>
 
-<table class="table table-hover" id="missing-mass"></table>
+<table class="table table-hover" id="missing-mass-table"></table>
 
-<h2 id="h1">Missing Solubility</h2>
+<h2 id="missing-solubility">Missing Solubility</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2177">solubility</a>
 of a compound is always in some solvent and depending on the temperature. The
 latter two are therefore commonly given as qualifiers, as for this
 <a href="https://www.wikidata.org/wiki/Property:P2177#P1855">example</a>.
 
-<table class="table table-hover" id="missing-solubility"></table>
+<table class="table table-hover" id="missing-solubility-table"></table>
 
-<h2 id="h1">Missing Enthalpy of Formation</h2>
+<h2 id="missing-enthalpy">Missing Enthalpy of Formation</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P3078">enthalpy of formation</a>
 is a measure of the stability of the compound.
 
-<table class="table table-hover" id="missing-enthalpy-of-formation"></table>
+<table class="table table-hover" id="missing-enthalpy-table"></table>
 
-<h2 id="h1">Missing Vapor Pressure</h2>
+<h2 id="missing-vapor-pressure">Missing Vapor Pressure</h2>
 
-<table class="table table-hover" id="missing-vapor-pressure"></table>
+<table class="table table-hover" id="missing-vapor-pressure-table"></table>
 
-<h2 id="h1">Missing Molar Entropy</h2>
+<h2 id="missing-molar-entropy">Missing Molar Entropy</h2>
 
-<table class="table table-hover" id="missing-molar-entropy"></table>
+<table class="table table-hover" id="missing-molar-entropy-table"></table>
 
-<h2 id="h1">Missing Density</h2>
+<h2 id="missing-density">Missing Density</h2>
 
-<table class="table table-hover" id="missing-density"></table>
+<table class="table table-hover" id="missing-density-table"></table>
 
-<h2 id="h1">Missing Chemical Structure</h2>
+<h2 id="missing-chemical-structure">Missing Chemical Structure</h2>
 
-<table class="table table-hover" id="missing-chemical-structure"></table>
+<table class="table table-hover" id="missing-chemical-structure-table"></table>
 
-<h2 id="h1">Missing Flash Point</h2>
+<h2 id="missing-flash-point">Missing Flash Point</h2>
 
-<table class="table table-hover" id="missing-flash-point"></table>
+<table class="table table-hover" id="missing-flash-point-table"></table>
 
-<h2 id="h1">Missing pKa</h2>
+<h2 id="missing-pka">Missing pKa</h2>
 
-<table class="table table-hover" id="missing-pKa"></table>
+<table class="table table-hover" id="missing-pka-table"></table>
 
-<h2 id="h1">Missing Combustion Enthalpy</h2>
+<h2 id="missing-combustion-enthalpy">Missing Combustion Enthalpy</h2>
 
-<table class="table table-hover" id="missing-combustion-enthalpy"></table>
+<table class="table table-hover" id="missing-combustion-enthalpy-table"></table>
 
-<h2 id="h1">Missing IDLH</h2>
+<h2 id="missing-idlh">Missing IDLH</h2>
 
 The <a href="https://www.wikidata.org/wiki/Property:P2129">Immediately Dangerous to Life and Health value</a>
 (IDLH) is an indication provided by the U.S. <a href="{{ url_for('app.show_organization_empty') }}Q583725">CDC</a> about the danger of the compound.
 
-<table class="table table-hover" id="missing-idlh"></table>
+<table class="table table-hover" id="missing-idlh-table"></table>
 
 {% endblock %}

--- a/scholia/app/templates/clinical_trial.html
+++ b/scholia/app/templates/clinical_trial.html
@@ -151,18 +151,17 @@ ORDER BY DESC(?score)
 
 {% block page_content %}
 
-<h1 id="h1">Clinical trial</h1>
+<h1 id="clinical-trial">Clinical trial</h1>
 
-<div id="intro"></div>
+<div id="clinical-trial-intro"></div>
 
-<h2>Data</h2>
+<h2 id="clinical-trial-data">Data</h2>
 
-<table class="table table-hover" id="data"></table>
+<table class="table table-hover" id="clinical-trial-data-table"></table>
 
+<h2 id="clinical-trial-related-trials">Related trials</h2>
 
-<h2>Related trials</h2>
-
-<table class="table table-hover" id="related-trials"></table>
+<table class="table table-hover" id="clinical-trial-related-trials-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/clinical_trial_empty.html
+++ b/scholia/app/templates/clinical_trial_empty.html
@@ -127,31 +127,31 @@ ORDER BY DESC(?count)
 <h1>Clinical trials</h1>
 
 <h2 title="Recently initiated clinical trials"
-    id="Recent clinical trials">Recent clinical trials</h2>
+    id="recent-clinical-trials">Recent clinical trials</h2>
 
-<table class="table table-hover" id="recent-clinical-trials"></table>
+<table class="table table-hover" id="recent-clinical-trials-table"></table>
 
-<h2 title="Clinical trial phases during the years">Phases</h2>
+<h2 title="Clinical trial phases during the years" id="clinical-trials-phases">Phases</h2>
 
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="clinical-trials-phases-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%0A%20%20%28STR%28%3Fyear_%29%20AS%20%3Fyear%29%0A%20%20%3Fcount%0A%20%20%3Fphase%20%3FphaseLabel%0AWHERE%20%7B%0A%20%20%7B%20%0A%20%20%20%20SELECT%0A%20%20%20%20%20%20%3Fyear_%0A%20%20%20%20%20%20%28COUNT%28%2a%29%20AS%20%3Fcount%29%0A%20%20%20%20%20%20%3Fphase%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20%3Ftrial%20wdt%3AP6099%20%3Fphase%20.%0A%20%20%20%20%20%20%3Ftrial%20wdt%3AP580%20%3Fstart_datetime%20.%0A%20%20%20%20%20%20BIND%28YEAR%28%3Fstart_datetime%29%20AS%20%3Fyear_%29%20%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fyear_%20%3Fphase%0A%20%20%7D%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D"></iframe>
 </div>
 
 
-<h2 title="Medical conditions in clinical trials sorted by number of trials">Medical conditions</h2>
+<h2 id="medical-conditions" title="Medical conditions in clinical trials sorted by number of trials">Medical conditions</h2>
 
-<table class="table table-hover" id="medical-conditions"></table>
-
-
-<h2 title="Interventions in clinical trials sorted by number of trials">Interventions</h2>
-
-<table class="table table-hover" id="interventions"></table>
+<table class="table table-hover" id="medical-conditions-table"></table>
 
 
-<h2 title="Statistics for clinical trials">Statistics</h2>
+<h2 id="interventions" title="Interventions in clinical trials sorted by number of trials">Interventions</h2>
 
-<table class="table table-hover" id="statistics"></table>
+<table class="table table-hover" id="interventions-table"></table>
+
+
+<h2 id="statistics" title="Statistics for clinical trials">Statistics</h2>
+
+<table class="table table-hover" id="statistics-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/countries.html
+++ b/scholia/app/templates/countries.html
@@ -77,12 +77,12 @@ WHERE {
 
 {% block page_content %}
 
-<h1 id="h1">Countries</h1>
+<h1 id="countries">Countries</h1>
 
-<div id="intro"></div>
+<div id="countries-intro"></div>
 
 
-<table class="table table-hover" id="list-of-countries"></table>
+<table class="table table-hover" id="countries-table"></table>
 
 
 

--- a/scholia/app/templates/country.html
+++ b/scholia/app/templates/country.html
@@ -83,7 +83,7 @@ ORDER BY DESC(?number_of_citing_works)
 
 <div id="country-intro"></div>
 
-<div id="country-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 id="organizations">Organizations</h2>

--- a/scholia/app/templates/country.html
+++ b/scholia/app/templates/country.html
@@ -79,16 +79,16 @@ ORDER BY DESC(?number_of_citing_works)
 
 {% block page_content %}
 
-<h1 id="h1">Country</h1>
+<h1 id="country">Country</h1>
 
-<div id="intro"></div>
+<div id="country-intro"></div>
 
-<div id="wembedder"></div>
+<div id="country-wembedder"></div>
 
 
-<h2 id="Organization">Organizations</h2>
+<h2 id="organizations">Organizations</h2>
 
-<table class="table table-hover" id="organizations"></table>
+<table class="table table-hover" id="organizations-table"></table>
 
 
 <!--
@@ -104,34 +104,34 @@ ORDER BY DESC(?number_of_citing_works)
    -->
 
 
-<h2 id="Authors">Authors</h2>
+<h2 id="authors">Authors</h2>
 
-<table class="table table-hover" id="authors"></table>
+<table class="table table-hover" id="authors-table"></table>
 
 
 
-<h2 id="Locations-as-topics">Locations as topics</h2>
+<h2 id="locations-as-topics">Locations as topics</h2>
 
 Locations in the country that are the topic of a work.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="locations-as-topics-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%7B%22markercluster%22%3Atrue%7D.%0ASELECT%20%0A%20%20%3Flocation%20%3FlocationLabel%20%0A%20%20%3Fwork%20%3FworkLabel%20%0A%20%20%3Fgeo%0A%20%20%3Flayer%0AWITH%20%7B%0A%20%20SELECT%20%3Flocation%20%3Fwork%20%3Fgeo%20%3Ftype%20WHERE%20%7B%0A%20%20%20%20%3Flocation%20wdt%3AP17%20wd%3A{{ q }}%20.%0A%20%20%20%20%0A%20%20%20%20%23%20Geocoordinates%20may%20possible%20be%20under%20a%20headquarter%20property%0A%20%20%20%20%3Flocation%20wdt%3AP159%3F%20%2F%20wdt%3AP625%20%3Fgeo.%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Flocation%20.%0A%20%20%20%20%0A%20%20%20%20%23%20Filter%20encyclopedic%20articles%20-%20that%20may%20not%20be%20so%20relevant%0A%20%20%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fwork%20wdt%3AP31%20wd%3AQ17329259%20%7D%0A%20%20%7D%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20%20%20%20%20%20%20%20%20%0A%20%20%23%20Move%20here%20for%20speed%20of%20query%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP31%20%2F%20rdfs%3Alabel%20%3Flayer%20.%20%0A%20%20%20%20FILTER%20%28LANG%28%3Flayer%29%20%3D%20%27en%27%29%0A%20%20%7D%0A%20%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%20"></iframe>
 </div>
 
-<h2 id="Narrative locations">Narrative locations</h2>
+<h2 id="narrative-locations">Narrative locations</h2>
 
 Locations used as narrative locations in works.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="narrative-locations-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%7B%22markercluster%22%3Atrue%7D.%0ASELECT%20%0A%20%20%3Flocation%20%3FlocationLabel%20%0A%20%20%3Fwork%20%3FworkLabel%20%0A%20%20%3Fgeo%0A%20%20%3Flayer%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Flocation%20%3Fwork%20%3Fgeo%20%3Flayer%20WHERE%20%7B%0A%20%20%20%20%3Flocation%20wdt%3AP17%20wd%3A{{ q }}%20.%0A%20%20%20%20%0A%20%20%20%20%23%20Geocoordinates%20may%20possible%20be%20under%20a%20headquarter%20property%0A%20%20%20%20%3Flocation%20wdt%3AP159%3F%20%2F%20wdt%3AP625%20%3Fgeo.%0A%20%20%20%20%3Fwork%20wdt%3AP840%20%3Flocation%20.%0A%20%20%20%20%0A%20%20%20%20%23%20Filter%20encyclopedic%20articles%20-%20that%20may%20not%20be%20so%20relevant%0A%20%20%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fwork%20wdt%3AP31%20wd%3AQ17329259%20%7D%0A%0A%20%20%20%20OPTIONAL%20%7B%20%3Fwork%20wdt%3AP31%20%2F%20rdfs%3Alabel%20%3Flayer%20.%20FILTER%20%28LANG%28%3Flayer%29%20%3D%20%27en%27%29%20%7D%0A%20%20%7D%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%20%0A%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%20"></iframe>
 </div>
 
 
-<h2 id="Co-organizations">Co-organizations</h2>
+<h2 id="co-organizations">Co-organizations</h2>
 
 International organizations with co-authors.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="co-organizations-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%0ASELECT%20%3Fcoorganization%20%3FcoorganizationLabel%20%3Fgeocoordinates%20%3Fexample_coauthor%20%3Fexample_coauthorLabel%20%3Fexample_work%20%3Fexample_workLabel%0AWITH%20%7B%20%20%0A%20%20SELECT%0A%20%20%20%20%3Fcoorganization%0A%20%20%20%20%28SAMPLE%28%3Fgeocoordinates_%29%20AS%20%3Fgeocoordinates%29%0A%20%20%20%20%28SAMPLE%28%3Fcoauthor%29%20AS%20%3Fexample_coauthor%29%0A%20%20%20%20%28SAMPLE%28%3Fwork%29%20AS%20%3Fexample_work%29%0A%20%20WHERE%20%7B%0A%20%20%20%20%3Forganization%20wdt%3AP17%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fauthor%20wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20wdt%3AP1416%2Fwdt%3AP361%2a%20%3Forganization%20.%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%2C%20%3Fcoauthor%20.%0A%20%20%20%20%3Fcoauthor%20wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20wdt%3AP1416%2Fwdt%3AP361%2a%20%3Fcoorganization%20.%0A%20%20%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fcoorganization%20wdt%3AP17%20wd%3A{{ q }}%20%7D%0A%20%20%20%20%3Fcoorganization%20wdt%3AP625%20%3Fgeocoordinates_%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fcoorganization%20%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%0A%7D"></iframe>"></iframe>
 </div>
 

--- a/scholia/app/templates/country_topic.html
+++ b/scholia/app/templates/country_topic.html
@@ -51,28 +51,28 @@ ORDER BY DESC(?number_of_works)
 
 {% block page_content %}
 
-<h1 id="h1">Country-topic</h1>
+<h1 id="country-topic">Country-topic</h1>
 
-<div id="intro"></div>
-
-
-<h2 id="Authors">Authors of the country who published on the topics</h2>
-
-<table class="table table-hover" id="authors"></table>
+<div id="country-topic-intro"></div>
 
 
-<h2 id="Co-author graph">Co-author graph</h2>
+<h2 id="authors">Authors of the country who published on the topics</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<table class="table table-hover" id="authors-table"></table>
+
+
+<h2 id="co-author-graph">Co-author graph</h2>
+
+<div id="co-author-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%0A%20%20%3Fauthor1%20%3Fauthor1Label%0A%20%20%3Fauthor2%20%3Fauthor2Label%0AWITH%20%7B%20%20%0A%20%20SELECT%0A%20%20%20%20DISTINCT%20%0A%20%20%20%20%3Fauthor1%0A%20%20%20%20%3Fauthor2%0A%20%20WHERE%20%7B%0A%20%20%20%20%3Fauthor1%20%28%20wdt%3AP108%20%7C%20wdt%3AP1416%20%29%20%2F%20wdt%3AP17%20wd%3A{{ q1 }}%20.%0A%20%20%20%20%3Fauthor2%20%28%20wdt%3AP108%20%7C%20wdt%3AP1416%20%29%20%2F%20wdt%3AP17%20wd%3A{{ q1 }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%2F%20%28wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%20%7C%20%28wdt%3AP31%2a%20%2F%20wdt%3AP279%2a%29%20%29%20wd%3A{{ q2 }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor1%20.%20%20%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor2%20.%0A%20%20%20%20FILTER%20%28%3Fauthor1%20%21%3D%20%3Fauthor2%29%0A%20%20%7D%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0A"></iframe>
 </div>
 
 
-<h2 id="Co-citation graph">Co-citation graph</h2>
+<h2 id="co-citation-graph">Co-citation graph</h2>
 
 Citations between authors of the country who published on the topic.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="co-citation-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%0A%20%20%3Fauthor1%20%3Fauthor1Label%0A%20%20%3Fauthor2%20%3Fauthor2Label%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fauthor1%20%3Fwork1%20WHERE%20%7B%0A%20%20%20%20hint%3AQuery%20hint%3Aoptimizer%20%22None%22.%0A%20%20%20%20%3Fauthor1%20%28%20wdt%3AP108%20%7C%20wdt%3AP1416%20%29%20%2F%20wdt%3AP17%20wd%3A{{ q1 }}%20.%0A%20%20%20%20%3Fwork1%20wdt%3AP50%20%3Fauthor1%20.%0A%20%20%20%20%3Fwork1%20wdt%3AP921%20%2F%20%28wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%20%7C%20%28wdt%3AP31%2a%20%2F%20wdt%3AP279%2a%29%20%29%20wd%3A{{ q2 }}%20.%0A%20%20%7D%0A%7D%20AS%20%25author1%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fauthor2%20%3Fwork2%20WHERE%20%7B%0A%20%20%20%20hint%3AQuery%20hint%3Aoptimizer%20%22None%22.%0A%20%20%20%20%3Fauthor2%20%28%20wdt%3AP108%20%7C%20wdt%3AP1416%20%29%20%2F%20wdt%3AP17%20wd%3A{{ q1 }}%20.%0A%20%20%20%20%3Fwork2%20wdt%3AP50%20%3Fauthor2%20.%0A%20%20%20%20%3Fwork2%20wdt%3AP921%20%2F%20%28wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%20%7C%20%28wdt%3AP31%2a%20%2F%20wdt%3AP279%2a%29%20%29%20wd%3A{{ q2 }}%20.%0A%20%20%7D%0A%7D%20AS%20%25author2%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20DISTINCT%20%0A%20%20%20%20%3Fauthor1%0A%20%20%20%20%3Fauthor2%20%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25author1%0A%20%20%20%20INCLUDE%20%25author2%0A%20%20%20%20%7B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%3Fwork1%20wdt%3AP2860%20%2F%20wdt%3AP50%20%3Fauthor2%20.%0A%20%20%20%20%7D%0A%20%20%20%20UNION%20%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%3Fauthor1%20%5Ewdt%3AP50%20%2F%20wdt%3AP2860%20%3Fwork2%20.%0A%20%20%20%20%7D%20%20%0A%20%20%20%0A%20%20%20%20FILTER%20%28%3Fauthor1%20%21%3D%20%3Fauthor2%29%0A%20%20%7D%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/disease.html
+++ b/scholia/app/templates/disease.html
@@ -84,7 +84,7 @@ ORDER BY DESC(?count)
 
 <div id="disease-intro"></div>
 
-<div id="disease-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 id="clinical-trials">Clinical trials</h2>

--- a/scholia/app/templates/disease.html
+++ b/scholia/app/templates/disease.html
@@ -80,30 +80,30 @@ ORDER BY DESC(?count)
 
 
 {% block page_content %}
-<h1 id="h1">Disease</h1>
+<h1 id="disease">Disease</h1>
 
-<div id="intro"></div>
+<div id="disease-intro"></div>
 
-<div id="wembedder"></div>
-
-
-<h2 id="Clinical trials">Clinical trials</h2>
-
-<table class="table table-hover" id="clinical-trials"></table>
+<div id="disease-wembedder"></div>
 
 
-<h2 id="Related diseases">Possibly related diseases</h2>
+<h2 id="clinical-trials">Clinical trials</h2>
+
+<table class="table table-hover" id="clinical-trials-table"></table>
+
+
+<h2 id="related-diseases">Possibly related diseases</h2>
 
 Other diseases with reported genetic association via genes or symptom overlap, 
 ordered according to number of co-associated genes and symptoms.
 
 
-<table class="table table-hover" id="related-diseases"></table>
+<table class="table table-hover" id="related-diseases-table"></table>
 
 
-<h2 id="Publications per year">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="publications-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0A%23%20Inspired%20from%20LEGOLAS%20-%20http%3A%2F%2Fabel.lis.illinois.edu%2Flegolas%2F%0A%23%20Shubhanshu%20Mishra%2C%20Vetle%20Torvik%0Aselect%20%3Fyear%20%28count%28%3Fwork%29%20as%20%3Fnumber_of_publications%29%20where%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%28str%28%3Fyear_%29%20as%20%3Fyear%29%20%280%20as%20%3Fpages%29%20where%20%7B%0A%20%20%20%20%20%20%23%20default%20values%20%3D%200%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20%20%20bind%28year%28%3Fdate%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20select%20%28min%28%3Fyear_%29%20as%20%3Fearliest_year%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP361%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fpublication_date%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20bind%28year%28now%28%29%29%20as%20%3Fnext_year%29%0A%20%20%20%20%20%20filter%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Fnext_year%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20union%20%7B%0A%20%20%20%20select%20%3Fwork%20%28min%28%3Fyears%29%20as%20%3Fyear%29%20where%20%7B%0A%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP361%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdates%20.%0A%20%20%20%20%20%20bind%28str%28year%28%3Fdates%29%29%20as%20%3Fyears%29%20.%0A%20%20%20%20%7D%0A%20%20%20%20group%20by%20%3Fwork%20%0A%20%20%7D%0A%7D%0Agroup%20by%20%3Fyear%20%0Aorder%20by%20%3Fyear"></iframe>
 </div>
 

--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -304,65 +304,65 @@ ORDER BY DESC(?score)
 
 {% block page_content %}
 
-<h1 id="h1">Event</h1>
+<h1 id="event">Event</h1>
 
-<div id="intro"></div>
+<div id="event-intro"></div>
 
-<div id="details"></div>
-
-
-<h2>People</h2>
-
-<table class="table table-hover" id="people"></table>
+<div id="event-details"></div>
 
 
-<h3>Co-author graph</h3>
+<h2 id="people">People</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<table class="table table-hover" id="people-table"></table>
+
+
+<h3 id="coauthor-graph">Co-author graph</h3>
+
+<div id="coauthor-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%20%0A%20%20%3Fauthor1%20%3Fauthor1Label%20%28SAMPLE%28%3Fimage1_%29%20AS%20%3Fimage1%29%20%3Frgb%0A%20%20%3Fauthor2%20%3Fauthor2Label%20%28SAMPLE%28%3Fimage2_%29%20AS%20%3Fimage2%29%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%3Fauthor1%0A%20%20%20%20%28SAMPLE%28%3Fdark_rgb_%29%20AS%20%3Fdark_rgb%29%0A%20%20%20%20%28SAMPLE%28%3Flight_rgb_%29%20AS%20%3Flight_rgb%29%0A%20%20WHERE%20%7B%0A%20%20%20%20%23%20Find%20people%20at%20the%20event%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20wd%3A{{ q }}%20%28wdt%3AP823%20%7C%20wdt%3AP664%20%7C%20%5Ewdt%3AP1344%20%7C%20wdt%3AP710%29%20%3Fauthor1%20.%20%0A%20%20%20%20%20%20BIND%20%28%22EEEEEE%22%20AS%20%3Fdark_rgb_%29%0A%20%20%20%20%7D%0A%20%20%20%20UNION%20%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%23%20author%20of%20article%20in%20proceedings%2C%20or%20program%20committee%20member%0A%20%20%20%20%20%20wd%3A{{ q }}%20%20%28%5Ewdt%3AP4745%20%2F%20%5Ewdt%3AP1433%20%2F%20wdt%3AP50%29%20%7C%20wdt%3AP5804%20%3Fauthor1%20.%20%20%0A%20%20%20%20%20%20BIND%20%28%22FFFFFF%22%20AS%20%3Flight_rgb_%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor1%0A%7D%20AS%20%25authors%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fauthor1%20%3Fauthor2%20%3Frgb%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25authors%0A%20%20%20%20wd%3A{{ q }}%20%28wdt%3AP823%20%7C%20wdt%3AP664%20%7C%20%5Ewdt%3AP1344%20%7C%20wdt%3AP710%20%7C%20%5Ewdt%3AP4745%20%2F%20%5Ewdt%3AP1433%20%2F%20wdt%3AP50%29%20%20%3Fauthor2%20.%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%23%20Find%20co-authors%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor1%20%2C%20%3Fauthor2%20.%0A%20%20%20%20FILTER%20%28%3Fauthor1%20%21%3D%20%3Fauthor2%29%0A%0A%20%20%20%20BIND%28COALESCE%28%3Fdark_rgb%2C%20%3Flight_rgb%29%20AS%20%3Frgb%29%0A%20%20%7D%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20%20%20%0A%20%20OPTIONAL%20%7B%20%3Fauthor1%20wdt%3AP18%20%3Fimage1_%20.%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fauthor2%20wdt%3AP18%20%3Fimage2_%20.%20%7D%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Csv%2Cru%2Czh%22.%0A%20%20%7D%0A%7D%0AGROUP%20BY%20%3Fauthor1%20%3Fauthor1Label%20%3Frgb%20%3Fauthor2%20%3Fauthor2Label%20%20%0A%20"></iframe>
 </div>
 
 
-<h2>Timeline</h2>
+<h2 id="timeline">Timeline</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="timeline-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ATimeline%0ASELECT%20%3Ftime%20%3Fitem%20%3FitemLabel%20%3Fimage%0AWHERE%20%7B%0A%20%20%7B%0A%20%20%20%20wd%3A{{ q }}%20wdt%3AP580%20%7C%20wdt%3AP585%20%3Ftime%20.%0A%20%20%20%20OPTIONAL%20%7B%20wd%3A{{ q }}%20wdt%3AP18%20%3Fimage%20.%20%7D%0A%20%20%20%20BIND%28wd%3AQ24575110%20AS%20%3Fitem%29%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20wd%3A{{ q }}%20wdt%3AP582%20%3Ftime%20.%0A%20%20%20%20OPTIONAL%20%7B%20wd%3A{{ q }}%20wdt%3AP18%20%3Fimage%20.%20%7D%0A%20%20%20%20BIND%28wd%3AQ24575125%20AS%20%3Fitem%29%0A%20%20%7D%0A%20%20UNION%20%0A%20%20%7B%20wd%3A{{ q }}%20p%3AP793%20%5B%20ps%3AP793%20%3Fitem%20%3B%20pq%3AP585%20%3Ftime%20%5D%20.%20%7D%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%0A%7D%0A%20%20%0A%20%20"></iframe>
 </div>
 
 
-<h2>Topic scores</h2>
+<h2 id="topic-scores">Topic scores</h2>
 
-<table class="table table-hover" id="topics"></table>
+<table class="table table-hover" id="topic-scores-table"></table>
 
 
 <h2>Works</h2>
 
-<h3>Recent publications</h3>
+<h3 id="recent-publications">Recent publications</h3>
 
 Recent publications by organizers, speakers or participants of the event.
 
-<table class="table table-hover" id="recent-publications"></table>
+<table class="table table-hover" id="recent-publications-table"></table>
 
-<h3>Proceedings publications</h3>
+<h3 id="proceedings-publications">Proceedings publications</h3>
 
 Works published in the proceedings related to the event.
 
-<table class="table table-hover" id="proceedings-publications"></table>
+<table class="table table-hover" id="proceedings-publications-table"></table>
 
 
 <h2>Related events</h2>
 
-<h3>Related based on time and location</h3>
+<h3 id="related-events-time-location">Related based on time and location</h3>
 
-<table class="table table-hover" id="related-events-time-location"></table>
+<table class="table table-hover" id="related-events-time-location-table"></table>
 
 
-<h3>Related based on people</h3>
+<h3 id="related-events-people">Related based on people</h3>
 
 Related event based on overlap among participants, organizers, editors,
 authors and program committee members. 
 
-<table class="table table-hover" id="related-events-people"></table>
+<table class="table table-hover" id="related-events-people-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/event_empty.html
+++ b/scholia/app/templates/event_empty.html
@@ -141,19 +141,19 @@ LIMIT 200
 
 <h1>Events</h1>
 
-<h2 id="Coming deadlines">Coming deadlines</h2>
+<h2 id="coming-deadlines">Coming deadlines</h2>
 
-<table class="table table-hover" id="coming-deadlines"></table>
-
-
-<h2 id="Future events">Future events</h2>
-
-<table class="table table-hover" id="future-events"></table>
+<table class="table table-hover" id="coming-deadlines-table"></table>
 
 
-<h2 id="Future events">Past events</h2>
+<h2 id="future-events">Future events</h2>
 
-<table class="table table-hover" id="past-events"></table>
+<table class="table table-hover" id="future-events-table"></table>
+
+
+<h2 id="past-events">Past events</h2>
+
+<table class="table table-hover" id="past-events-table"></table>
 
 
 

--- a/scholia/app/templates/event_series.html
+++ b/scholia/app/templates/event_series.html
@@ -279,35 +279,35 @@ WHERE {
 
 {% block page_content %}
 
-<h1 id="h1">Event</h1>
+<h1 id="event">Event</h1>
 
-<div id="intro"></div>
+<div id="event-intro"></div>
 
-<div id="details"></div>
-
-
-<h2>List of events</h2>
-
-<table class="table table-hover" id="list-of-events"></table>
+<div id="event-details"></div>
 
 
-<h2>Timeline</h2>
+<h2 id="list-of-events">List of events</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<table class="table table-hover" id="list-of-events-table"></table>
+
+
+<h2 id="event-timeline">Timeline</h2>
+
+<div id="event-timeline-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe loading="lazy" class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ATimeline%0ASELECT%0A%20%20%3Ftime%20%3Fendtime%20%3Fevent%20%3FeventLabel%20%3Fimage%0A%20%20%3Fdescription%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fevent%20%3Ftime%20%3Fendtime%20WHERE%20%7B%0A%20%20%20%20%23%20It%20seems%20to%20be%20necessary%20to%20have%20this%20line%20together%20with%20the%20%0A%20%20%20%20%23%20optional%20event%20time%20triples%20here.%0A%20%20%20%20%3Fevent%20wdt%3AP179%20%7C%20wdt%3AP31%20wd%3A{{ q }}%20.%0A%20%20%20%20%0A%20%20%20%20OPTIONAL%20%7B%20%3Fevent%20wdt%3AP580%20%3Fstarttime%20.%20%7D%0A%0A%20%20%20%20%23%20If%20the%20endtime%20is%20not%20set%2C%20then%20use%20now%20as%20the%20end%20time%0A%20%20%20%20%23%20However%20this%20does%20not%20show%20well%20if%20the%20event%20is%20in%20the%20future%0A%20%20%20%20%23%20and%20no%20end%20date%20has%20been%20set.%0A%20%20%20%20OPTIONAL%20%7B%20%3Fevent%20wdt%3AP582%20%3Fendtime%20.%20%7D%0A%20%20%20%20%23%20BIND%28COALESCE%28%3Fendtime_%2C%20NOW%28%29%29%20AS%20%3Fendtime%29%0A%20%20%20%20%0A%20%20%20%20OPTIONAL%20%7B%20%3Fevent%20wdt%3AP585%20%3Ftimepoint%20.%20%7D%0A%20%20%20%20%0A%20%20%20%20%23%20If%20start%20time%20is%20defined%20the%20disregard%20timepoint%0A%20%20%20%20BIND%28COALESCE%28%3Fstarttime%2C%20%3Ftimepoint%29%20AS%20%3Ftime%29%0A%20%20%7D%0A%7D%20AS%20%25events1%0AWITH%20%7B%0A%20%20%23%20Include%20significant%20events%0A%20%20SELECT%20%3Fevent%20%3Ftime%20%3Fdescription%20WHERE%20%7B%0A%20%20%20%20%3Fevent%20wdt%3AP179%20%7C%20wdt%3AP31%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fevent%20p%3AP793%20%5B%20ps%3AP793%20%3Fitem%20%3B%20pq%3AP585%20%3Ftime%20%5D%20.%0A%20%20%20%20OPTIONAL%20%7B%0A%20%20%20%20%20%20%3Fitem%20rdfs%3Alabel%20%3Fdescription%20.%0A%20%20%20%20%20%20FILTER%20%28LANG%28%3Fdescription%29%20%3D%20%22en%22%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%20AS%20%25events2%0AWHERE%20%7B%0A%20%20%7B%20INCLUDE%20%25events1%20%7D%0A%20%20UNION%0A%20%20%7B%20INCLUDE%20%25events2%20%7D%0A%20%20%20%20%20%20%20%20%20%20%0A%20%20OPTIONAL%20%7B%20%3Fevent%20wdt%3AP18%20%3Fimage%20.%20%7D%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%0A%20%20%7D%0A%7D%0A%20%20%0A%20%20"></iframe>
 </div>
 
 
-<h2>Map</h2>
+<h2 id="event-map">Map</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="event-map-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe loading="lazy" class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%0ASELECT%20%3Fevent%20%3FeventLabel%20%3Fgeo%20%3Fimage%20WHERE%20%7B%0A%20%20%3Fevent%20%28wdt%3AP179%20%7C%20wdt%3AP31%29%20wd%3A{{ q }}%20.%0A%20%20%3Fevent%20wdt%3AP276%3F%20%2F%20wdt%3AP625%20%3Fgeo%20.%0A%20%20OPTIONAL%20%7B%20%3Fevent%20wdt%3AP18%20%3Fimage%20.%20%7D%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D"></iframe>
 </div>
 
 
-<h2>Topic scores</h2>
+<h2 id="event-topic-scores">Topic scores</h2>
 
-<table class="table table-hover" id="topics"></table>
+<table class="table table-hover" id="event-topic-scores-table"></table>
 
 
 <h2>Persons</h2>

--- a/scholia/app/templates/event_series.html
+++ b/scholia/app/templates/event_series.html
@@ -310,18 +310,18 @@ WHERE {
 <table class="table table-hover" id="event-topic-scores-table"></table>
 
 
-<h2>Persons</h2>
+<h2 id="persons">Persons</h2>
 
-<table class="table table-hover" id="persons"></table>
+<table class="table table-hover" id="persons-table"></table>
 
 
 <h2>Works</h2>
 
-<h3>Recent publications</h3>
+<h3 id="recent-publications">Recent publications</h3>
 
 Recent publications by organizers, speakers or participants of the events in the series.
 
-<table class="table table-hover" id="recent-publications"></table>
+<table class="table table-hover" id="recent-publications-table"></table>
 
 <h3>Proceedings publications</h3>
 

--- a/scholia/app/templates/event_series_empty.html
+++ b/scholia/app/templates/event_series_empty.html
@@ -42,9 +42,9 @@ ORDER BY DESC(?events)
 
 {% block page_content %}
 
-<h1>Event series</h1>
+<h1 id="event-series">Event series</h1>
 
-<table class="table table-hover" id="event-series"></table>
+<table class="table table-hover" id="event-series-table"></table>
 
 
 

--- a/scholia/app/templates/gene.html
+++ b/scholia/app/templates/gene.html
@@ -97,34 +97,34 @@ WHERE {
 
 
 {% block page_content %}
-<h1 id="h1">Gene</h1>
+<h1 id="gene">Gene</h1>
 <script type="application/ld+json" id="bioschemas"></script>
 
-<div id="intro"></div>
+<div id="gene-intro"></div>
 
-<h2 id="Transcripts">Transcripts</h2>
+<h2 id="gene-ranscripts">Transcripts</h2>
 
 Transcripts encoded by this gene.
 
-<table class="table table-hover" id="transcripts"></table>
+<table class="table table-hover" id="gene-transcripts-table"></table>
 
-<h2 id="Proteins">Proteins</h2>
+<h2 id="proteins">Proteins</h2>
 
 Proteins encoded by this gene.
 
-<table class="table table-hover" id="proteins"></table>
+<table class="table table-hover" id="proteins-table"></table>
 
-<h2 id="Orthologs">Orthologs</h2>
+<h2 id="orthologs">Orthologs</h2>
 
 Orthologs encoded by this gene.
 
-<table class="table table-hover" id="orthologs"></table>
+<table class="table table-hover" id="orthologs-table"></table>
 
-<h2 id="Variants">Variants</h2>
+<h2 id="variants">Variants</h2>
 
 Variants encoded by this gene.
 
-<table class="table table-hover" id="variants"></table>
+<table class="table table-hover" id="variants-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/lexeme.html
+++ b/scholia/app/templates/lexeme.html
@@ -42,12 +42,12 @@ SELECT DISTINCT ?work ?workLabel ?workDescription {
        href="https://tools.wmflabs.org/ordia/{{ lexeme }}">Ordia 🔗</a>
 </p>
 
-<h1 id="h1">Lexeme</h1>
+<h1 id="lexeme">Lexeme</h1>
 
 
-<h2>Works</h2>
+<h2 id="lexeme-works">Works</h2>
 
-<table class="table table-hover" id="works"></table>
+<table class="table table-hover" id="lexeme-works-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/lexeme_empty.html
+++ b/scholia/app/templates/lexeme_empty.html
@@ -52,9 +52,9 @@ ORDER BY DESC(?count)
 
 {% block page_content %}
 
-<h1>Lexeme</h1>
+<h1 id="lexeme">Lexeme</h1>
 
-<table class="table table-hover" id="lexemes"></table>
+<table class="table table-hover" id="lexeme-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/location.html
+++ b/scholia/app/templates/location.html
@@ -105,22 +105,22 @@ ORDER BY ?distance
 
 {% block page_content %}
 
-<h1 id="h1">Location</h1>
+<h1 id="location">Location</h1>
 
-<div id="intro"></div>
+<div id="location-intro"></div>
 
-<div id="wembedder"></div>
+<div id="location-wembedder"></div>
 
 
 <h2 title="Nearby academic organizations with distances in kilometers"
-    id="Nearby organizations">Nearby organizations</h2>
+    id="nearby-organizations">Nearby organizations</h2>
 
-<table class="table table-hover" id="nearby-organizations"></table>
+<table class="table table-hover" id="nearby-organizations-table"></table>
 
 
-<h2 id="Nearby locations as topics in works">Nearby locations as topics in works</h2>
+<h2 id="nearby-locations-as-topics-in-works">Nearby locations as topics in works</h2>
 
-<table class="table table-hover" id="nearby-locations-as-topics-in-works"></table>
+<table class="table table-hover" id="nearby-locations-as-topics-in-works-table"></table>
 
 
 

--- a/scholia/app/templates/location.html
+++ b/scholia/app/templates/location.html
@@ -109,7 +109,7 @@ ORDER BY ?distance
 
 <div id="location-intro"></div>
 
-<div id="location-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 title="Nearby academic organizations with distances in kilometers"

--- a/scholia/app/templates/location_topic.html
+++ b/scholia/app/templates/location_topic.html
@@ -76,14 +76,14 @@ ORDER BY DESC(?score)
 
 {% block page_content %}
 
-<h1 id="h1">Location-topic</h1>
+<h1 id="location-topic">Location-topic</h1>
 
-<div id="intro"></div>
+<div id="location-topic-intro"></div>
 
 
-<h2 id="Nearby researchers">Nearby researchers</h2>
+<h2 id="nearby-researchers">Nearby researchers</h2>
 
-<table class="table table-hover" id="nearby-researchers"></table>
+<table class="table table-hover" id="nearby-researchers-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/organization.html
+++ b/scholia/app/templates/organization.html
@@ -176,46 +176,46 @@ WHERE {
 
 {% block page_content %}
 
-<h1 id="h1">Organization</h1>
+<h1 id="organizations">Organization</h1>
 
-<div id="intro"></div>
+<div id="organizations-intro"></div>
 
-<div id="wembedder"></div>
+<div id="organizations-wembedder"></div>
 
 
-<h2 id="Employees-and-affiliated">Employees and affiliated</h2>
+<h2 id="employees-and-affiliated">Employees and affiliated</h2>
 
 Past and present employees, affiliated, and members<br/>
 
-<table class="table table-hover" id="employees-and-affiliated"></table>
+<table class="table table-hover" id="employees-and-affiliated-table"></table>
 
 
-<h2 id="Co-author-graph">Co-author graph</h2>
+<h2 id="co-author-graph">Co-author graph</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="co-author-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe loading="lazy" class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%0A%20%20%3Fauthor1%20%3Fauthor1Label%20%3Fimage1%20%3Frgb%0A%20%20%3Fauthor2%20%3Fauthor2Label%20%3Fimage2%20%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%3Fauthor1%20%28SAMPLE%28%3Fimage1_%29%20AS%20%3Fimage1%29%0A%20%20%20%20%3Fauthor2%20%28SAMPLE%28%3Fimage2_%29%20AS%20%3Fimage2%29%0A%20%20%20%20%28SAMPLE%28%3Frgb_%29%20AS%20%3Frgb%29%0A%20%20WHERE%20%7B%0A%20%20%20%20wd%3A{{ q }}%20%5Ewdt%3AP361%2a%20%2F%20%5E%28%20wdt%3AP108%20%7C%20wdt%3AP1416%20%7C%20wdt%3AP463%20%29%20%3Fauthor1%20%2C%20%3Fauthor2%20.%20%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor1%20%2C%20%3Fauthor2%20.%0A%0A%20%20%20%20%23%20Only%20display%20co-authorship%20for%20certain%20types%20of%20documents%0A%20%20%20%20%23%20Journal%20and%20conference%20articles%2C%20books%2C%20not%20%28yet%3F%29%20software%0A%20%20%20%20VALUES%20%3Fpublication_type%20%7B%20wd%3AQ13442814%20wd%3AQ571%20wd%3AQ26973022%20wd%3AQ17928402%20wd%3AQ947859%20wd%3AQ54670950%20%7D%0A%20%20%20%20FILTER%20EXISTS%20%7B%20%3Fwork%20wdt%3AP31%20%3Fpublication_type%20.%20%7D%0A%0A%20%20%20%20%23%20No%20self-links.%0A%20%20%20%20FILTER%20%28%3Fauthor1%20%21%3D%20%3Fauthor2%29%0A%0A%20%20%20%20%23%20Images%0A%20%20%20%20OPTIONAL%20%7B%20%3Fauthor1%20wdt%3AP18%20%3Fimage1_%20%7D%0A%20%20%20%20OPTIONAL%20%7B%20%3Fauthor2%20wdt%3AP18%20%3Fimage2_%20%7D%0A%0A%20%20%20%20%23%20Coloring%20of%20the%20nodes%0A%20%20%20%20BIND%28%22FFFFFF%22%20AS%20%3Frgb_%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor1%20%3Fauthor2%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Csv%2Cru%2Czh%22.%0A%20%20%7D%0A%7D%0A"></iframe>
 </div>
 
 
-<h2 id="Co-author-graph">Advisor graph</h2>
+<h2 id="advisor-graph">Advisor graph</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="advisor-graph-table" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%20%3Fauthor1%20%3Fauthor1Label%20%3Frgb%20%3Fauthor2%20%3Fauthor2Label%20%0AWITH%20%7B%0A%20%20SELECT%20%3Fauthor1%20%3Fauthor2%20%3Frgb%20WHERE%20%7B%0A%20%20%20%20%7B%20%3Fauthor1%20wdt%3AP108%20wd%3A{{ q }}%20.%20%7D%20union%20%7B%20%3Fauthor1%20wdt%3AP1416%20%5B%20wdt%3AP361%2a%20wd%3A{{ q }}%20%5D%20.%20%20%7D%0A%20%20%20%20%7B%20%3Fauthor2%20wdt%3AP108%20wd%3A{{ q }}%20.%20%7D%20union%20%7B%20%3Fauthor2%20wdt%3AP1416%20%5B%20wdt%3AP361%2a%20wd%3A{{ q }}%20%5D%20.%20%20%7D%0A%20%20%20%20%7B%3Fauthor1%20wdt%3AP184%20%3Fauthor2%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%3Fauthor2%20wdt%3AP185%20%3Fauthor1%20%7D%0A%20%20%20%20%3Fauthor1%20wdt%3AP21%20%3Fgender1%20.%20%0A%20%20%20%20BIND%20%28%20IF%28%3Fgender1%20%3D%20wd%3AQ6581097%2C%20%223182BD%22%2C%20%22E6550D%22%29%20AS%20%3Frgb%29%0A%20%20%7D%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Csv%2Cru%2Czh%22.%0A%20%20%7D%0A%7D%0A"></iframe>
 </div>
 
 
-<h2 id="Topics that employees and affiliates have published on">Topics that employees and affiliates have published on</h2>
+<h2 id="topics-employees-affiliates-published">Topics that employees and affiliates have published on</h2>
 
 Topics of publications by past and present employees, affiliates, and members, ranked by number of individuals having published on the topic.<br/>
 
-<table class="table table-hover" id="topics"></table>
+<table class="table table-hover" id="topics-employees-affiliates-published-table"></table>
 
-<h2 id="Recent-publications">Recent publications <a href="{{ url_for('app.show_organization_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recent-publications">Recent publications <a href="{{ url_for('app.show_organization_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<table class="table table-hover" id="recent-publications"></table>
+<table class="table table-hover" id="recent-publications-table"></table>
 
 
-<h2 id="Page-production">Page production</h2>
+<h2 id="page-production">Page production</h2>
 
 Page production per year per author.
 The number of pages for a multiple-author paper is distributed among
@@ -235,30 +235,30 @@ has been set.
 <table class="table table-hover" id="recent-citations"></table>
 
 
-<h3>Most cited papers with affiliated first author</h2>
+<h3 id="most-cited">Most cited papers with affiliated first author</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="most-cited-iframe" class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0A%23%20Bubble%20chart%20of%20most%20cited%20works%20of%20first%20author%20associated%0A%23%20with%20an%20organization%0ASELECT%0A%20%20%3Fcount%20%3Fwork%20%3FworkLabel%0AWITH%20%7B%0A%20%20%23%20Find%20researchers%20associated%20with%20the%20organization%20and%20count%0A%20%20%23%20the%20number%20of%20citations.%0A%20%20SELECT%0A%20%20%20%20%28COUNT%28DISTINCT%20%3Fciting_work%29%20AS%20%3Fcount%29%0A%20%20%20%20%3Fwork%0A%20%20WHERE%20%7B%0A%20%20%20%20%3Fresearcher%20wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20%28wdt%3AP1416%20%2F%20wdt%3AP361%2a%29%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20p%3AP50%20%3Fresearcher_statement%20.%0A%20%20%20%20%3Fresearcher_statement%20ps%3AP50%20%3Fresearcher%20.%0A%20%20%20%20%3Fresearcher_statement%20pq%3AP1545%20%221%22%20.%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fwork%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%20%20LIMIT%2020%0A%7D%20AS%20%25works%0AWHERE%20%7B%0A%20%20%23%20Label%20the%20works%0A%20%20INCLUDE%20%25works%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%0A%20%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29"></iframe>
 </div>
 
 
-<h3>Co-author-normalized citations per year</h2>
+<h3 id="coauthor-citations">Co-author-normalized citations per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="coauthor-citations-iframe" class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%20%3Fyear%20%28SUM%28%3Fcitations_per_author_%29%20AS%20%3Fcitations_per_author%29%20%3FresearcherLabel%0AWITH%20%7B%0A%20%20%23%20Find%20researchers%20affiliated%20with%20the%20organization%0A%20%20SELECT%20DISTINCT%20%3Fresearcher%20WHERE%20%7B%0A%20%20%20%20%3Fresearcher%20wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20wdt%3AP1416%2Fwdt%3AP361%2a%20wd%3A{{ q }}%20.%0A%20%20%7D%0A%7D%20AS%20%25researchers%20%0AWITH%20%7B%0A%20%20%23%20Find%20works%20of%20the%20researchers%20and%20count%20the%20number%20of%20citations%0A%20%20SELECT%0A%20%20%20%20%3Fresearcher%20%3Fwork%20%3Fyear%20%28COUNT%28DISTINCT%20%3Fciting_work%29%20%2F%20COUNT%28DISTINCT%20%3Fresearcher_of_paper%29%20AS%20%3Fcitations_per_author_%29%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25researchers%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%7C%20wdt%3AP2093%20%3Fresearcher_of_paper%20.%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fresearcher%20.%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%0A%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdate%20.%20%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fdate%29%29%20AS%20%3Fyear%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fwork%20%3Fresearcher%20%3Fyear%0A%7D%20AS%20%25counts%0AWHERE%20%7B%0A%20%20%23%20Label%20the%20results%0A%20%20INCLUDE%20%25counts%20%20%20%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AGROUP%20BY%20%3Fyear%20%3Fresearcher%20%3FresearcherLabel%0AORDER%20BY%20%3Fyear%0A"></iframe>
 </div>
 
 
-<h2 id="Awards">Awards</h2>
+<h2 id="awards">Awards</h2>
 
-<table class="table table-hover" id="awards"></table>
+<table class="table table-hover" id="awards-table"></table>
 
 
-<h2 id="Gender-distribution">Gender distribution</h2>
+<h2 id="gender-distribution">Gender distribution</h2>
 
 Count of the number of researchers wrt. gender.
 
-<table class="table table-hover" id="gender-distribution"></table>
+<table class="table table-hover" id="gender-distribution-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/organization.html
+++ b/scholia/app/templates/organization.html
@@ -180,7 +180,7 @@ WHERE {
 
 <div id="organizations-intro"></div>
 
-<div id="organizations-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 id="employees-and-affiliated">Employees and affiliated</h2>

--- a/scholia/app/templates/organization_missing.html
+++ b/scholia/app/templates/organization_missing.html
@@ -149,34 +149,34 @@ ORDER BY DESC(?works)
 
 {% block page_content %}
 
-<h1 id="h1">Organization</h1>
+<h1 id="organization">Organization</h1>
 
 Missing information with respect to the organization.
 
-<h2 id="h2">Missing author items</h2>
+<h2 id="missing-author-items">Missing author items</h2>
 
 The authors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
 Follow the link to use the Author disambiguator tool to try to resolve
 the authors.
 
-<table class="table table-hover" id="missing-author-items"></table>
+<table class="table table-hover" id="missing-author-items-table"></table>
 
 <h2 id="h3">Author name strings to be resolved</h2>
 
 
-<h3 id="h31">Author name strings without initials</h3>
+<h3 id="missing-author-no-initials">Author name strings without initials</h3>
 
 The author may be represented as a string rather than a Wikidata item.
 Follow the link to use the Author disambiguator tool to try to resolve the author name.
 To facilitate curation, author name strings containing single-letter initials have been removed from this table.
-<table class="table table-hover" id="missing-author-no-initials"></table>
+<table class="table table-hover" id="missing-author-no-initials-table"></table>
 
-<h3 id="h32">Author name strings with initials</h3>
+<h3 id="missing-author-resolving-initials">Author name strings with initials</h3>
 
 This table shows author name strings that contain single-letter initials.
 
-<table class="table table-hover" id="missing-author-resolving-initials"></table> 
+<table class="table table-hover" id="missing-author-resolving-initials-table"></table> 
 
 
 {% endblock %}

--- a/scholia/app/templates/organization_topic.html
+++ b/scholia/app/templates/organization_topic.html
@@ -42,14 +42,14 @@ LIMIT 200
 
 {% block page_content %}
 
-<h1 id="h1">Organization-topic</h1>
+<h1 id="organization-topic">Organization-topic</h1>
 
-<div id="intro"></div>
+<div id="organization-topic-intro"></div>
 
 
-<h2 class="headline" id="Recent-publications"><a href="#Recent-publications">Recent publications</a></h2>
+<h2 class="headline" id="recent-publications"><a href="#Recent-publications">Recent publications</a></h2>
 
-<table class="table table-hover" id="recent-publications"></table>
+<table class="table table-hover" id="recent-publications-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/organizations.html
+++ b/scholia/app/templates/organizations.html
@@ -100,55 +100,55 @@ LIMIT 100
 
 {% block page_content %}
 
-<h1 id="h1">Organizations</h1>
+<h1 id="organizations">Organizations</h1>
 
-<div id="intro"></div>
+<div id="organizations-intro"></div>
 
-<table class="table table-hover" id="list-of-organizations"></table>
+<table class="table table-hover" id="list-of-organizations-table"></table>
 
 
-<h2 id="Co-authorships">Co-authorships</h2>
+<h2 id="co-authorships">Co-authorships</h2>
 
 <p>Past and present employees, affiliated, and members shared between organizations</p>
 
-<table class="table table-hover" id="co-authorships"></table>
+<table class="table table-hover" id="co-authorships-table"></table>
 
 
-<h2 id="Works per year">Works per year</h2>
+<h2 id="works-per-year">Works per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="works-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%20%3Fyear%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_works%29%20%3Forganization%20%3ForganizationLabel%20%20%0AWHERE%20%7B%0A%20%20%7B%0A%20%20%20%20SELECT%20DISTINCT%20%3Fyear%20%3Fwork%20%3Forganization%20WHERE%20%7B%0A%20%20%20%20%20%20hint%3AQuery%20hint%3Aoptimizer%20%22None%22.%0A%20%20%20%20%20%20VALUES%20%3Forganization%20%7B%20%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%20%7D%0A%20%20%20%20%20%20%3Fauthor%20wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20%28wdt%3AP1416%2Fwdt%3AP361%2a%29%20%3Forganization%20.%20%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%0A%20%20%20%20%20%20BIND%28STR%28YEAR%28%3Fpublication_date%29%29%20AS%20%3Fyear%29%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fwork%20%3Fyear%20%3Forganization%0A%20%20%7D%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%7D%0AGROUP%20BY%20%3Fyear%20%3Forganization%20%3ForganizationLabel%0AORDER%20BY%20%3Fyear%0A%20"></iframe>
 </div>
 
 
-<h2 id="Citations per year">Citations per year</h2>
+<h2 id="citations-per-year">Citations per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
-    <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%0A%20%20%3Fyear_of_citation%0A%20%20%3Fnumber_of_citations%0A%20%20%3Forganization%20%3ForganizationLabel%20%20%0AWITH%20%7B%0A%20%20%23%20Bind%20organizations%20to%20variable%0A%20%20SELECT%20%3Forganization%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Forganization%20%7B%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%7D%0A%20%20%7D%0A%7D%20AS%20%25organizations%0AWITH%20%7B%0A%20%20%23%20Find%20works%20author%20by%20the%20organization%0A%20%20SELECT%0A%20%20%20%20DISTINCT%20%3Fwork%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25organizations%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%2F%20%28wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20%28wdt%3AP1416%2Fwdt%3AP361%2a%29%29%20%3Forganization%20.%20%0A%20%20%7D%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20%23%20Count%20citations%20per%20year%20per%20organization%0A%20%20SELECT%0A%20%20%20%20%3Fyear_of_citation%0A%20%20%20%20%28COUNT%28%3Fciting_work%29%20AS%20%3Fnumber_of_citations%29%0A%20%20%20%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%20%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fpublication_date%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fpublication_date%29%29%20AS%20%3Fyear_of_citation%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear_of_citation%20%3Forganization%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20%23%20Since%201990%0A%20%20%23%20FILTER%20%28%3Fyear_of_citation%20%3E%3D%20%221990%22%29%0A%20%20%0A%20%20%23%20Label%20the%20results%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20%3Fyear_of_citation%0A%20"></iframe></div>
+<div id="citations-per-year-iframe" class="embed-responsive embed-responsive-16by9">
+    <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%0A%20%20%3Fyear_of_citation%0A%20%20%3Fnumber_of_citations%0A%20%20%3Forganization%20%3ForganizationLabel%20%20%0AWITH%20%7B%0A%20%20%23%20Bind%20organizations%20to%20variable%0A%20%20SELECT%20%3Forganization%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Forganization%20%7B%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%7D%0A%20%20%7D%0A%7D%20AS%20%25organizations%0AWITH%20%7B%0A%20%20%23%20Find%20works%20author%20by%20the%20organization%0A%20%20SELECT%0A%20%20%20%20DISTINCT%20%3Fwork%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25organizations%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%2F%20%28wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20%28wdt%3AP1416%2Fwdt%3AP361%2a%29%29%20%3Forganization%20.%20%0A%20%20%7D%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20%23%20Count%20citations%20per%20year%20per%20organization%0A%20%20SELECT%0A%20%20%20%20%3Fyear_of_citation%0A%20%20%20%20%28COUNT%28%3Fciting_work%29%20AS%20%3Fnumber_of_citations%29%0A%20%20%20%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%20%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fpublication_date%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fpublication_date%29%29%20AS%20%3Fyear_of_citation%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear_of_citation%20%3Forganization%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20%23%20Since%201990%0A%20%20%23%20FILTER%20%28%3Fyear_of_citation%20%3E%3D%20%221990%22%29%0A%20%20%0A%20%20%23%20Label%20the%20results%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20%3Fyear_of_citation%0A%20"></iframe>
+</div>
 
 
-<h2 id="Citations to work ratio">Citations to works ratio</h2>
+<h2 id="citations-to-work-ratio">Citations to works ratio</h2>
 
 The ratio between the number of citations received and the works authored
 per organization per year.
 
-<div class="embed-responsive embed-responsive-16by9">
-    <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%0A%20%20%28%3Fyear_of_citation%20AS%20%3Fyear%29%0A%20%20%28%3Fnumber_of_citations%2F%3Fnumber_of_works%20AS%20%3Fcitations_to_works_ratio%29%0A%20%20%3Fnumber_of_works%0A%20%20%3Fnumber_of_citations%0A%20%20%3Forganization%20%3ForganizationLabel%20%20%0AWITH%20%7B%0A%20%20%23%20Bind%20organizations%20to%20variable%0A%20%20SELECT%20%3Forganization%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Forganization%20%7B%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%7D%0A%20%20%7D%0A%7D%20AS%20%25organizations%0AWITH%20%7B%0A%20%20%23%20Find%20works%20associated%20with%20the%20organizations%0A%20%20SELECT%0A%20%20%20%20%23%20Should%20not%20count%20authors%20twice%0A%20%20%20%20DISTINCT%20%3Fwork%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25organizations%0A%20%20%20%20%3Fauthor%20wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20%28wdt%3AP1416%2Fwdt%3AP361%2a%29%20%3Forganization%20.%20%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%7D%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20%23%20Count%20the%20number%20of%20works%20published%20per%20year%20per%20organization%0A%20%20SELECT%0A%20%20%20%20%3Fyear_of_cited%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_works%29%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fcited_publication_date%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fcited_publication_date%29%29%20AS%20%3Fyear_of_cited%29%0A%20%20%7D%20%0A%20%20GROUP%20BY%20%3Fyear_of_cited%20%3Forganization%0A%7D%20AS%20%25work_numbers%0AWITH%20%7B%0A%20%20%23%20Count%20the%20number%20of%20citations%20received%20per%20year%20per%20organization%0A%20%20SELECT%20%0A%20%20%20%20%3Fyear_of_citation%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_citations%29%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%20%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fciting_publication_date%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fciting_publication_date%29%29%20AS%20%3Fyear_of_citation%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear_of_citation%20%3Forganization%0A%7D%20AS%20%25citation_numbers%0AWHERE%20%7B%0A%20%20%23%20Join%20the%20work%20and%20citation%20counts%0A%20%20INCLUDE%20%25citation_numbers%0A%20%20INCLUDE%20%25work_numbers%0A%20%20FILTER%20%28%3Fyear_of_citation%20%3D%20%3Fyear_of_cited%29%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20%3Fyear_of_citation%0A%20"></iframe></div>
+<div id="citations-to-work-ratio-iframe" class="embed-responsive embed-responsive-16by9">
+    <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%0A%20%20%28%3Fyear_of_citation%20AS%20%3Fyear%29%0A%20%20%28%3Fnumber_of_citations%2F%3Fnumber_of_works%20AS%20%3Fcitations_to_works_ratio%29%0A%20%20%3Fnumber_of_works%0A%20%20%3Fnumber_of_citations%0A%20%20%3Forganization%20%3ForganizationLabel%20%20%0AWITH%20%7B%0A%20%20%23%20Bind%20organizations%20to%20variable%0A%20%20SELECT%20%3Forganization%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Forganization%20%7B%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%7D%0A%20%20%7D%0A%7D%20AS%20%25organizations%0AWITH%20%7B%0A%20%20%23%20Find%20works%20associated%20with%20the%20organizations%0A%20%20SELECT%0A%20%20%20%20%23%20Should%20not%20count%20authors%20twice%0A%20%20%20%20DISTINCT%20%3Fwork%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25organizations%0A%20%20%20%20%3Fauthor%20wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20%28wdt%3AP1416%2Fwdt%3AP361%2a%29%20%3Forganization%20.%20%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%7D%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20%23%20Count%20the%20number%20of%20works%20published%20per%20year%20per%20organization%0A%20%20SELECT%0A%20%20%20%20%3Fyear_of_cited%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_works%29%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fcited_publication_date%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fcited_publication_date%29%29%20AS%20%3Fyear_of_cited%29%0A%20%20%7D%20%0A%20%20GROUP%20BY%20%3Fyear_of_cited%20%3Forganization%0A%7D%20AS%20%25work_numbers%0AWITH%20%7B%0A%20%20%23%20Count%20the%20number%20of%20citations%20received%20per%20year%20per%20organization%0A%20%20SELECT%20%0A%20%20%20%20%3Fyear_of_citation%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_citations%29%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%20%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fciting_publication_date%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fciting_publication_date%29%29%20AS%20%3Fyear_of_citation%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear_of_citation%20%3Forganization%0A%7D%20AS%20%25citation_numbers%0AWHERE%20%7B%0A%20%20%23%20Join%20the%20work%20and%20citation%20counts%0A%20%20INCLUDE%20%25citation_numbers%0A%20%20INCLUDE%20%25work_numbers%0A%20%20FILTER%20%28%3Fyear_of_citation%20%3D%20%3Fyear_of_cited%29%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20%3Fyear_of_citation%0A%20"></iframe>
+</div>
 
 
-<h2 id="Topics">Topics</h2>
+<h2 id="topics">Topics</h2>
 
 Tree map of most common topics in works authored by people associated with the
 organizations. 
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="topics-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ATreeMap%0ASELECT%0A%20%20%3Fnumber_of_works%0A%20%20%3Ftopic%20%3FtopicLabel%0A%20%20%3Forganization%20%3ForganizationLabel%20%20%0AWITH%20%7B%0A%20%20%23%20Bind%20organizations%20to%20variable%0A%20%20SELECT%20%3Forganization%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Forganization%20%7B%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%7D%0A%20%20%7D%0A%7D%20AS%20%25organizations%0AWITH%20%7B%0A%20%20%23%20Find%20works%20associated%20with%20the%20organizations%0A%20%20SELECT%0A%20%20%20%20%23%20Should%20not%20count%20authors%20twice%0A%20%20%20%20DISTINCT%20%3Fwork%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25organizations%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%2F%20%28wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20%28wdt%3AP1416%2Fwdt%3AP361%2a%29%29%20%3Forganization%20.%20%0A%20%20%7D%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20%23%20Count%20the%20number%20of%20works%20per%20topic%20per%20organization%0A%20%20SELECT%0A%20%20%20%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_works%29%20%3Ftopic%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Ftopic%20.%0A%20%20%7D%20%0A%20%20GROUP%20BY%20%3Ftopic%20%3Forganization%0A%7D%20AS%20%25work_numbers%0AWHERE%20%7B%0A%20%20%23%20Join%20the%20work%20and%20citation%20counts%0A%20%20INCLUDE%20%25work_numbers%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fnumber_of_works%29%0ALIMIT%20100%0A%20"></iframe>
 </div>
 
 
-
-<table class="table table-hover" id="topic-tree-map"></table>
-
+<table class="table table-hover" id="topic-tree-map-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -149,34 +149,34 @@ $(document).ready(function() {
 
 
 {% block page_content %}
-<h1 id="h1">Pathway</h1>
+<h1 id="pathway">Pathway</h1>
 
-<div id="intro"></div>
+<div id="pathway-intro"></div>
 
-<div id="description"></div><br />
+<div id="pathway-description"></div><br />
 
-<div id="pathway-viewer" class="embed-responsive embed-responsive-16by9">
+<div id="pathway-viewer-iframe" class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" src="" style="border-width: 1px; border-color: rgb(222,226,230); border-style: solid;" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
 </div>
 
-<h2 id="Organism">Organism</h2>
+<h2 id="organism">Organism</h2>
 
-<h2 id="Participants">Participants</h2>
+<h2 id="participants">Participants</h2>
 
-<table class="table table-hover" id="participants"></table>
+<table class="table table-hover" id="participants-table"></table>
 
-<h2 id="Published works related to the pathway">Published works related to the pathway</h2>
+<h2 id="recent-articles">Published works related to the pathway</h2>
 
-<table class="table table-hover" id="recentArticles"></table>
+<table class="table table-hover" id="recent-articles-table"></table>
 
 
-<h2 id="Works citing this pathway">Works citing this pathway</h2>
+<h2 id="citing-articles">Works citing this pathway</h2>
 
-<table class="table table-hover" id="citingArticles"></table>
+<table class="table table-hover" id="citing-articles-table"></table>
 
-<h2 id="Publications per year">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="publications-per-year-iframe" class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0A%23%20Inspired%20from%20LEGOLAS%20-%20http%3A%2F%2Fabel.lis.illinois.edu%2Flegolas%2F%0A%23%20Shubhanshu%20Mishra%2C%20Vetle%20Torvik%0Aselect%20%3Fyear%20%28count%28%3Fwork%29%20as%20%3Fnumber_of_publications%29%20where%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%28str%28%3Fyear_%29%20as%20%3Fyear%29%20%280%20as%20%3Fpages%29%20where%20%7B%0A%20%20%20%20%20%20%23%20default%20values%20%3D%200%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20%20%20bind%28year%28%3Fdate%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20select%20%28min%28%3Fyear_%29%20as%20%3Fearliest_year%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP921%20%2F%20%28wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%20%7C%20%28wdt%3AP31%2a%20%2F%20wdt%3AP279%2a%29%20%29%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%20%20%20%20%7D%20union%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP2860%20%3Fwork%20.%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fpublication_date%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20bind%28year%28now%28%29%29%20as%20%3Fnext_year%29%0A%20%20%20%20%20%20filter%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Fnext_year%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20union%20%7B%0A%20%20%20%20select%20%3Fwork%20%28min%28%3Fyears%29%20as%20%3Fyear%29%20where%20%7B%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP921%20%2F%20%28wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%20%7C%20%28wdt%3AP31%2a%20%2F%20wdt%3AP279%2a%29%20%29%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%7D%20union%20%7B%0A%20%20%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP2860%20%3Fwork%20.%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdates%20.%0A%20%20%20%20%20%20bind%28str%28year%28%3Fdates%29%29%20as%20%3Fyears%29%20.%0A%20%20%20%20%7D%0A%20%20%20%20group%20by%20%3Fwork%20%0A%20%20%7D%0A%7D%0Agroup%20by%20%3Fyear%20%0Aorder%20by%20%3Fyear" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
 </div>
 

--- a/scholia/app/templates/pathway_empty.html
+++ b/scholia/app/templates/pathway_empty.html
@@ -53,9 +53,9 @@
 </div>
 
 <div class="container">
-  <h2>Statistics</h2>
+  <h2 id="statistics">Statistics</h2>
 
-  <table class="table table-hover" id="statistics"></table>
+  <table class="table table-hover" id="statistics-table"></table>
 
 </div>
 

--- a/scholia/app/templates/printer.html
+++ b/scholia/app/templates/printer.html
@@ -49,13 +49,13 @@ LIMIT 1000
 
 
 {% block page_content %}
-<h1 id="h1">Printer</h1>
+<h1 id="printer">Printer</h1>
 
-<div id="intro"></div>
+<div id="printer-intro"></div>
 
-<h2 id="Printed works">Printed works</h2>
+<h2 id="printed-works">Printed works</h2>
 
-<table class="table table-hover" id="printed-works"></table>
+<table class="table table-hover" id="printed-works-table"></table>
 
 
 

--- a/scholia/app/templates/printer_empty.html
+++ b/scholia/app/templates/printer_empty.html
@@ -6,14 +6,14 @@
 
 
 
-<h3>Printed works per printer</h3>
+<h3 id="printed-works-per-publisher">Printed works per printer</h3>
 
-<table class="table table-hover" id="printed-works-per-publisher"></table>
+<table class="table table-hover" id="printed-works-per-publisher-table"></table>
 
 
-<h2 id="Map of printers">Map of printers</h2>
+<h2 id="map-of-printers">Map of printers</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="map-of-printers-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%7B%22layer%22%3A%20%22%3Fcounts%22%7D%0ASELECT%0A%20%20%3Fgeo%0A%20%20%3Fprinter%20%3FprinterLabel%20%3FprinterDescription%0A%20%20%3Fcounts%0A%20%20%3Fexample_work%20%3Fexample_workLabel%0AWHERE%20%7B%0A%20%20hint%3AQuery%20hint%3Aoptimizer%20%22None%22.%0A%20%20%7B%0A%20%20%20%20SELECT%0A%20%20%20%20%20%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%0A%20%20%20%20%20%20%3Fprinter%0A%20%20%20%20%20%20%28SAMPLE%28%3Fwork%29%20AS%20%3Fexample_work%29%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP872%20%3Fprinter%20.%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fprinter%0A%20%20%7D%0A%20%20BIND%28IF%28%3Fcount%20%3D%201%2C%20%221%22%2C%20IF%28%3Fcount%20%3C%3D%205%2C%20%222-5%22%2C%20IF%28%3Fcount%20%3C%3D%2010%2C%20%226-10%22%2C%20%2210%2B%22%29%29%29%20AS%20%3Fcounts%29%0A%20%20%3Fprinter%20wdt%3AP159%3F%20%2F%20wdt%3AP625%20%3Fgeo%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Cde%2Ces%2Cfr%2Cit%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0ALIMIT%201000%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/project.html
+++ b/scholia/app/templates/project.html
@@ -111,47 +111,47 @@ LIMIT 500
 
 
 {% block page_content %}
-<h1 id="h1">Project</h1>
+<h1 id="project">Project</h1>
 
-<div id="intro"></div>
+<div id="project-intro"></div>
 
-<h2 id="Project Partners">Project Partners</h2>
+<h2 id="project-partners">Project Partners</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="project-partners-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item"  src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%0ASELECT%20%3Fpartner%20%3FpartnerLabel%20%3Flocation%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fpartner%20%3Flocation%20WHERE%20%7B%0A%20%20%20%20wd%3A{{ q }}%20%28%5Ewdt%3AP1344%20%7C%20wdt%3AP710%29%2a%20%2F%20%28wdt%3AP527%20%7C%20wdt%3AP710%20%7C%20wdt%3AP1416%29%20%3Fpartner%20.%0A%20%20%20%20%3Fpartner%20wdt%3AP159%2a%20%2F%20wdt%3AP625%20%3Flocation%20.%0A%20%20%7D%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%0A%7D%0A"></iframe>
 </div>
 
 
-<h2>Timeline</h2>
+<h2 id="timeline">Timeline</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="timeline-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ATimeline%7B%22hide%22%3A%20%5B%22%3Fend_time%22%2C%20%22%3Fstart_time%22%5D%7D%0ASELECT%20DISTINCT%20%3Fstart_time%20%3Fend_time%20%3Fdescription%20WHERE%20%7B%0A%20%20%7B%20%20%0A%20%20%20%20wd%3A{{ q }}%20%28wdt%3AP571%20%7C%20wdt%3AP580%29%20%3Fstart_time%20%3B%0A%20%20%20%20%20%20%28wdt%3AP576%20%7C%20wdt%3AP582%29%20%3Fend_time%20.%0A%20%20%20%20BIND%28%22Project%20time%22%20AS%20%3Fdescription%29%0A%20%20%7D%20%0A%20%20UNION%20%0A%20%20%7B%20%20%0A%20%20%20%20wd%3A{{ q }}%20%28%5Ewdt%3AP1344%20%7C%20wdt%3AP710%29%2B%20%3Fproject%20.%0A%20%20%20%20%3Fproject%20%28wdt%3AP571%20%7C%20wdt%3AP580%29%20%3Fstart_time%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%28wdt%3AP576%20%7C%20wdt%3AP582%29%20%3Fend_time%20.%0A%20%20%20%20%3Fproject%20rdfs%3Alabel%20%3FprojectName%20.%0A%20%20%20%20FILTER%20%28lang%28%3FprojectName%29%20%3D%20%22en%22%29%0A%20%20%20%20BIND%28%3FprojectName%20AS%20%3Fdescription%29%0A%20%20%7D%20%20%20%0A%20%20UNION%20%0A%20%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP859%2F%28wdt%3AP1344%7C%5Ewdt%3AP710%29%2a%20wd%3A{{ q }}%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20wdt%3AP577%20%3Fstart_time%20.%0A%20%20%20%20BIND%28%22Publication%22%20AS%20%3Fdescription%29%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20%3Fevent%20wdt%3AP859%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fevent%20wdt%3AP585%20%7C%20wdt%3AP580%20%3Fstart_time%20.%0A%20%20%20%20BIND%28%22%F0%9F%93%85%20Sponsored%20event%22%20AS%20%3Fdescription%29%0A%20%20%7D%0A%7D"></iframe>
 </div>
 
 
-<h2 id="Recently published works about or funded by the project">Recently published works about or funded by the project</h2>
+<h2 id="recent-articles">Recently published works about or funded by the project</h2>
 
-<table class="table table-hover" id="recentArticles"></table>
+<table class="table table-hover" id="recent-articles-table"></table>
 
 
-<h2>Topic scores</h2>
+<h2 id="topic-scores">Topic scores</h2>
 
 Topics based on a weighting between fields of work,
 topics of research output and topics of citing works.  
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="topic-scores-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fscore%20%3Ftopic%20%3FtopicLabel%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%28SUM%28%3Fscore_%29%20AS%20%3Fscore%29%0A%20%20%20%20%3Ftopic%0A%20%20WHERE%20%7B%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP101%20%3Ftopic%20.%0A%20%20%20%20%20%20BIND%2820%20AS%20%3Fscore_%29%0A%20%20%20%20%7D%0A%20%20%20%20UNION%20%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%283%20AS%20%3Fscore_%29%20%3Ftopic%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP859%2Fwdt%3AP1344%2a%20wd%3A{{ q }}%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20wdt%3AP921%20%3Ftopic%20.%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%281%20AS%20%3Fscore_%29%20%3Ftopic%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP859%2Fwdt%3AP1344%2a%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP921%20%3Ftopic%20.%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic%0A%7D%20AS%20%25results%20%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Cde%2Ces%2Cjp%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fscore%29%0ALIMIT%20200"></iframe>
 </div>
 
-<h2 id="Authors">Authors</h3>
+<h2 id="authors">Authors</h3>
 
-<h3 id="Prolific authors">Prolific authors</h3>
+<h3 id="prolific-authors">Prolific authors</h3>
 
-<table class="table table-hover" id="prolific-authors"></table>
+<table class="table table-hover" id="prolific-authors-table"></table>
 
-<h2 id="Publications per year">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="publications-per-year-iframe" class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item"  src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0A%23%20Inspired%20from%20LEGOLAS%20-%20http%3A%2F%2Fabel.lis.illinois.edu%2Flegolas%2F%0A%23%20Shubhanshu%20Mishra%2C%20Vetle%20Torvik%0Aselect%20%3Fyear%20%28count%28%3Fwork%29%20as%20%3Fnumber_of_publications%29%20where%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%28str%28%3Fyear_%29%20as%20%3Fyear%29%20%280%20as%20%3Fpages%29%20where%20%7B%0A%20%20%20%20%20%20%23%20default%20values%20%3D%200%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20%20%20bind%28year%28%3Fdate%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20select%20%28min%28%3Fyear_%29%20as%20%3Fearliest_year%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP527%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP859%2Fwdt%3AP1344%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20wd%3A{{ q }}%20%3Fpropp%20%3Fstatement%20.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Fstatement%20a%20wikibase%3ABestRank%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20prov%3AwasDerivedFrom%2Fpr%3AP248%20%3Fwork%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fpublication_date%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20bind%28year%28now%28%29%29%20as%20%3Fnext_year%29%0A%20%20%20%20%20%20filter%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Fnext_year%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20union%20%7B%0A%20%20%20%20select%20%3Fwork%20%28min%28%3Fyears%29%20as%20%3Fyear%29%20where%20%7B%0A%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP527%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP859%2Fwdt%3AP1344%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20wd%3A{{ q }}%20%3Fpropp%20%3Fstatement%20.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Fstatement%20a%20wikibase%3ABestRank%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20prov%3AwasDerivedFrom%2Fpr%3AP248%20%3Fwork%20.%20%7D%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdates%20.%0A%20%20%20%20%20%20bind%28str%28year%28%3Fdates%29%29%20as%20%3Fyears%29%20.%0A%20%20%20%20%7D%0A%20%20%20%20group%20by%20%3Fwork%20%0A%20%20%7D%0A%7D%0Agroup%20by%20%3Fyear%20%0Aorder%20by%20%3Fyear" ></iframe>
 </div>
 

--- a/scholia/app/templates/project_empty.html
+++ b/scholia/app/templates/project_empty.html
@@ -83,13 +83,13 @@ Research projects.
 
 <div class="container">
 
-<h2>Statistics</h2>
+<h2 id="statistics">Statistics</h2>
 
-<table class="table table-hover" id="statistics"></table>
+<table class="table table-hover" id="statistics-table"></table>
 
-<h3>Citations per budget</h3>
+<h3 id="citations-per-budget">Citations per budget</h3>
 
-<table class="table table-hover" id="citations-per-budget"></table>
+<table class="table table-hover" id="citations-per-budget-table"></table>
 
 </div>
 

--- a/scholia/app/templates/property.html
+++ b/scholia/app/templates/property.html
@@ -30,21 +30,21 @@ LIMIT 500
 
 <h1>Property: {{ p }}</h1>
 
-<h2>Use</h2>
+<h2 id="use">Use</h2>
 
-<table class="table table-hover" id="use"></table>
+<table class="table table-hover" id="use-table"></table>
 
 
-<h2>Item counts</h2>
+<h2 id="item-counts">Item counts</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="item-counts-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Fs%20%3FsLabel%20%0AWITH%20%7B%0A%20%20SELECT%20%28COUNT%28%3Fo%29%20AS%20%3Fcount%29%20%3Fs%20WHERE%20%7B%0A%20%20%20%20%3Fs%20wdt%3A{{ p }}%20%3Fo%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fs%0A%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%20%20LIMIT%20100%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0A"></iframe>
 </div>
     
 
-<h2>Property value counts</h2>
+<h2 id="property-value-counts">Property value counts</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="property-value-counts-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Fo%20%3FoLabel%20%0AWITH%20%7B%0A%20%20SELECT%20%28COUNT%28%3Fs%29%20AS%20%3Fcount%29%20%3Fo%20WHERE%20%7B%0A%20%20%20%20%3Fs%20wdt%3A{{ p }}%20%3Fo%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fo%0A%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%20%20LIMIT%20100%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/protein.html
+++ b/scholia/app/templates/protein.html
@@ -65,10 +65,10 @@ LIMIT 500
 
 
 {% block page_content %}
-<h1 id="h1">Protein</h1>
+<h1 id="protein">Protein</h1>
 <script type="application/ld+json" id="bioschemas"></script>
 
-<div id="intro"></div>
+<div id="protein-intro"></div>
 
 <!-- 
      <h2 id="Similar proteins">Similar proteins</h2>
@@ -79,16 +79,16 @@ LIMIT 500
      <table class="table table-hover" id="similar-proteins"></table>
    -->
 
-<h2 id="Cofunctional proteins">Cofunctional proteins</h2>
+<h2 id="cofunctionalproteins">Cofunctional proteins</h2>
 
 Proteins sharing molecular function(s).
 
-<table class="table table-hover" id="cofunctional-proteins"></table>
+<table class="table table-hover" id="cofunctional-proteins-table"></table>
 
 
-<h2 id="Publications per year">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="publications-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0A%23%20Inspired%20from%20LEGOLAS%20-%20http%3A%2F%2Fabel.lis.illinois.edu%2Flegolas%2F%0A%23%20Shubhanshu%20Mishra%2C%20Vetle%20Torvik%0Aselect%20%3Fyear%20%28count%28%3Fwork%29%20as%20%3Fnumber_of_publications%29%20where%20%7B%0A%20%20%7B%0A%20%20%20%20select%20%28str%28%3Fyear_%29%20as%20%3Fyear%29%20%280%20as%20%3Fpages%29%20where%20%7B%0A%20%20%20%20%20%20%23%20default%20values%20%3D%200%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20%20%20bind%28year%28%3Fdate%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20select%20%28min%28%3Fyear_%29%20as%20%3Fearliest_year%29%20where%20%7B%0A%20%20%20%20%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP361%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_date%20.%20%0A%20%20%20%20%20%20%20%20%20%20bind%28year%28%3Fpublication_date%29%20as%20%3Fyear_%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20bind%28year%28now%28%29%29%20as%20%3Fnext_year%29%0A%20%20%20%20%20%20filter%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Fnext_year%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20union%20%7B%0A%20%20%20%20select%20%3Fwork%20%28min%28%3Fyears%29%20as%20%3Fyear%29%20where%20%7B%0A%20%20%20%20%20%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP31%2a%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP361%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20union%20%7B%20%3Fwork%20wdt%3AP921%2Fwdt%3AP1269%2B%20wd%3A{{ q }}%20.%20%7D%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdates%20.%0A%20%20%20%20%20%20bind%28str%28year%28%3Fdates%29%29%20as%20%3Fyears%29%20.%0A%20%20%20%20%7D%0A%20%20%20%20group%20by%20%3Fwork%20%0A%20%20%7D%0A%7D%0Agroup%20by%20%3Fyear%20%0Aorder%20by%20%3Fyear"></iframe>
 </div>
 

--- a/scholia/app/templates/publisher.html
+++ b/scholia/app/templates/publisher.html
@@ -98,7 +98,7 @@ ORDER BY DESC(?number_of_citations)
 
 <div id="published-intro"></div>
 
-<div id="published-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 id="journals">Journals and other collections</h2>

--- a/scholia/app/templates/publisher.html
+++ b/scholia/app/templates/publisher.html
@@ -94,50 +94,47 @@ ORDER BY DESC(?number_of_citations)
 
 {% block page_content %}
 
-<h1 id="h1">Publisher</h1>
+<h1 id="published">Publisher</h1>
 
-<div id="intro"></div>
+<div id="published-intro"></div>
 
-<div id="wembedder"></div>
-
-
-<h2>Journals and other collections</h2>
-
-<table class="table table-hover" id="journals"></table>
+<div id="published-wembedder"></div>
 
 
-<h2>Recently established journals</h2>
+<h2 id="journals">Journals and other collections</h2>
+
+<table class="table table-hover" id="journals-table"></table>
+
+
+<h2 id="recent-publications">Recently established journals</h2>
 
 At most 50 journals are displayed.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="recent-publications-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ATimeline%0ASELECT%20DISTINCT%20%3Fdatetime%20%3Fvenue%20%3FvenueLabel%20WHERE%20%7B%0A%20%20%23%20Publisher%0A%20%20%3Fvenue%20wdt%3AP123%20wd%3A{{ q }}%20.%0A%20%20%0A%20%20%23%20Periodic%20literature%0A%20%20%3Fvenue%20wdt%3AP31%20%2F%20wdt%3AP279%2a%20wd%3AQ1002697%20.%0A%20%20%0A%20%20%23%20When%20the%20journal%20was%20started%20%0A%20%20%3Fvenue%20wdt%3AP571%20%3Fdatetime.%0A%20%20%0A%20%20%23%20Label%20the%20journal%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fdatetime%29%0ALIMIT%2050"</iframe>
 </div>
 
 
-<h2>Editors</h2>
+<h2 id="list-of-editors">Editors</h2>
 
 Editors association with the publisher, e.g., by being editor of a journal or a
 proceeding published by the publisher.
 
-<table class="table table-hover" id="list-of-editors"></table>
+<table class="table table-hover" id="list-of-editors-table"></table>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="list-of-editors-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AImageGrid%0ASELECT%0A%20%20%3Fimage%0A%20%20%3Feditor%20%3FeditorLabel%20%0A%20%20%3Fvenues%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%0A%20%20%20%20%28SAMPLE%28%3Fimage_%29%20AS%20%3Fimage%29%0A%20%20%20%20%3Feditor%20%0A%20%20%20%20%28GROUP_CONCAT%28%3Fvenue_label%3B%20separator%3D%22%20%2F%2F%20%22%29%20AS%20%3Fvenues%29%0A%20%20WHERE%20%7B%0A%20%20%20%20%23%20Find%20editors%20for%20journals%20published%20by%20publisher%0A%20%20%20%20%3Fvenue_%20wdt%3AP123%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fvenue_%20wdt%3AP98%20%3Feditor%20.%0A%20%20%20%20%3Feditor%20wdt%3AP18%20%3Fimage_%20.%0A%20%20%20%20OPTIONAL%20%7B%0A%20%20%20%20%20%20%3Fvenue_%20rdfs%3Alabel%20%3Fvenue_label%20.%20FILTER%28LANG%28%3Fvenue_label%29%20%3D%20%27en%27%29%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Feditor%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Cfr%2Cjp%2Cnl%2Csv%2Cru%2Czh%22%20.%20%7D%20%0A%7D%0A"></iframe>
 </div>
 
-
-
-
 <h2>Citations</h2>
 
-<h3>Most cited papers</h3>
+<h3 id="most-cited">Most cited papers</h3>
 
-<table class="table table-hover" id="mostCited"></table>
+<table class="table table-hover" id="most-cited-table"></table>
 
-<h3 id="As function of number of published works">As function of number of published works</h3>
+<h3 id="function-number-published-works">As function of number of published works</h3>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="function-number-published-works-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AScatterChart%0ASELECT%20%3Fwork_count%20%3Fcitation_count%20%3Fjournal%20%3FjournalLabel%20%0AWITH%20%7B%0A%20%20SELECT%20%3Fwork_count%20%3Fcitation_count%20%3Fjournal%20%7B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%3Fjournal%20%28COUNT%28%3Fwork%29%20AS%20%3Fwork_count%29%20%7B%0A%20%20%09%20%20%20%20%3Fjournal%20wdt%3AP123%20wd%3A{{ q }}%20.%0A%20%20%09%20%20%20%20%3Fwork%20wdt%3AP1433%20%3Fjournal%20.%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20GROUP%20BY%20%3Fjournal%20%0A%20%20%20%20%7D%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%3Fjournal%20%28COUNT%28%3Fciting_work%29%20AS%20%3Fcitation_count%29%20%7B%0A%20%20%09%20%20%20%20%3Fjournal%20wdt%3AP123%20wd%3A{{ q }}%20.%0A%20%20%09%20%20%20%20%3Fwork%20wdt%3AP1433%20%3Fjournal%20.%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20GROUP%20BY%20%3Fjournal%20%0A%20%20%20%20%7D%20%0A%20%20%7D%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%20%0A%7D%0A%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/series.html
+++ b/scholia/app/templates/series.html
@@ -87,39 +87,39 @@ ORDER BY DESC(?number_of_works) DESC(?number_of_citations)
 
 
 {% block page_content %}
-<h1 id="h1">Series</h1>
+<h1 id="series">Series</h1>
 
-<div id="intro"></div>
+<div id="series-intro"></div>
 
-<div id="wembedder"></div>
-
-
-<h2 id="In series">In series</h2>
-
-<table class="table table-hover" id="in-series"></table>
+<div id="series-wembedder"></div>
 
 
-<h2 id="Published works">Published works</h2>
+<h2 id="in-series">In series</h2>
 
-<table class="table table-hover" id="published-works"></table>
+<table class="table table-hover" id="in-series-table"></table>
 
 
-<h2 id="Topics">Topics</h2>
+<h2 id="published-works">Published works</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<table class="table table-hover" id="published-works-table"></table>
+
+
+<h2 id="topics">Topics</h2>
+
+<div id="topics-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Ftopic%20%3FtopicLabel%0AWITH%20%7B%0A%20%20SELECT%20%28COUNT%28%2a%29%20AS%20%3Fcount%29%20%3Ftopic%0A%20%20WHERE%20%7B%0A%20%20%20%20%23%20Topics%20of%20series%0A%20%20%20%20%7B%20wd%3A{{ q }}%20wdt%3AP921%20%3Ftopic%20.%20%7D%0A%20%20%20%20%0A%20%20%20%20%23%20Topics%20of%20collections%20in%20series%0A%20%20%20%20UNION%20%7B%20%3Fcollection%20wdt%3AP179%20wd%3A{{ q }}%20%3B%20wdt%3AP921%20%3Ftopic%20.%20%7D%0A%20%20%20%20%0A%20%20%20%20%23%20Topics%20of%20works%20in%20collections%20in%20series%0A%20%20%20%20UNION%20%7B%20%3Fwork%20wdt%3AP1433%2Fwdt%3AP179%20wd%3A{{ q }}%20%3B%20wdt%3AP921%20%3Ftopic%20.%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0ADESC%28%3Fcount%29%0ALIMIT%20100%0A"></iframe>
 </div>
 
-<h2 id="Authors">Authors</h2>
+<h2 id="authors">Authors</h2>
 
-<table class="table table-hover" id="authors"></table>
+<table class="table table-hover" id="authors-table"></table>
 
 
-<h2 id="Organization">Organizations</h2>
+<h2 id="organization">Organizations</h2>
 
 Employment relationships per year.
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="organization-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%20%3Fyear%20%3Fcount%20%3Forganization%20%3ForganizationLabel%0AWITH%20%7B%0A%20%20SELECT%20%28MIN%28%3Fyear_%29%20AS%20%3Fyear%29%20%3Fwork%20WHERE%20%7B%0A%20%20%20%20%3Fcollection%20wdt%3AP179%20wd%3A{{ q }}%20.%20%0A%20%20%20%20%3Fwork%20wdt%3AP1433%20%3Fcollection%20.%0A%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdatetimes%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fdatetimes%29%29%20AS%20%3Fyear_%29%0A%20%20%7D%20%0A%20%20GROUP%20BY%20%3Fwork%0A%7D%20AS%20%25works%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Forganization%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%09%3Fwork%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%20%20%0A%20%20%20%20%23%20For%20now%2C%20only%20employment%20relation%0A%20%20%20%20%23%20We%20could%20add%20affiliation%20with%20%22%7C%20wdt%3AP1416%2Fwdt%3AP361%2a%22%20%0A%20%20%20%20%23%20Note%20that%20this%20extra%20term%20will%20double%20count.%0A%20%20%20%20%3Fauthor%20wdt%3AP108%20%20%3Forganization%20.%20%0A%20%20%20%7D%0A%20%20%20GROUP%20BY%20%3Fyear%20%3Forganization%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%20%20%20%23%20Exclude%20organizations%20with%20only%20a%20single%20count%0A%20%20%20%23%20HAVING%28%3Fcount%20%3E%201%29%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20INCLUDE%20%25result%0A%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20%7D%0A%7D%0AORDER%20BY%20%3Fyear%0A"></iframe></iframe>
 </div>
 

--- a/scholia/app/templates/series.html
+++ b/scholia/app/templates/series.html
@@ -91,7 +91,7 @@ ORDER BY DESC(?number_of_works) DESC(?number_of_citations)
 
 <div id="series-intro"></div>
 
-<div id="series-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 id="in-series">In series</h2>

--- a/scholia/app/templates/software.html
+++ b/scholia/app/templates/software.html
@@ -59,31 +59,31 @@ ORDER BY DESC(?count)
 
 
 {% block page_content %}
-<h1 id="h1">Software</h1>
+<h1 id="software">Software</h1>
 
-<div id="intro"></div>
+<div id="software-intro"></div>
 
-<h2 id="Recent work using the software">Recent work using the software</h2>
+<h2 id="recent-work-using-the-software">Recent work using the software</h2>
 
-<table class="table table-hover" id="recent-work-using-the-software"></table>
-
-
-<h2 id="Co-used">Co-used</h2>
-
-<table class="table table-hover" id="co-used"></table>
+<table class="table table-hover" id="recent-work-using-the-software-table"></table>
 
 
-<h2 id="Topics of works using the software">Topics of works using the software</h2>
+<h2 id="co-used">Co-used</h2>
+
+<table class="table table-hover" id="co-used-table"></table>
 
 
-<div class="embed-responsive embed-responsive-4by3">
+<h2 id="topics-of-works-using-the-software">Topics of works using the software</h2>
+
+
+<div id="topics-of-works-using-the-software-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Ftopic%20%3FtopicLabel%0AWITH%7B%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Ftopic%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP2283%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Ftopic%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0A"></iframe>
 </div>
 
-<h2 id="Authors of works using the software">Authors of works using the software</h2>
+<h2 id="authors-of-works-using-the-software">Authors of works using the software</h2>
 
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="authors-of-works-using-the-software-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Fauthor%20%3FauthorLabel%0AWITH%7B%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Fauthor%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP2283%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/software_empty.html
+++ b/scholia/app/templates/software_empty.html
@@ -58,9 +58,9 @@ LIMIT 500
 
 <h2>Overview</h2>
 
-<h3 id="most used software">Most used software</h3>
+<h3 id="most-used-software">Most used software</h3>
 
-<table class="table table-hover" id="most-used-software"></table>
+<table class="table table-hover" id="most-used-software-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/sponsor.html
+++ b/scholia/app/templates/sponsor.html
@@ -97,7 +97,7 @@ ORDER BY DESC(?count)
 
 <div id="sponsor-intro"></div>
 
-<div id="sponsor-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 id="recently-published-sponsored-work">Recently published sponsored work <a href="{{ url_for('app.show_sponsor_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>

--- a/scholia/app/templates/sponsor.html
+++ b/scholia/app/templates/sponsor.html
@@ -93,39 +93,39 @@ ORDER BY DESC(?count)
 
 
 {% block page_content %}
-<h1 id="h1">Sponsor</h1>
+<h1 id="sponsor">Sponsor</h1>
 
-<div id="intro"></div>
+<div id="sponsor-intro"></div>
 
-<div id="wembedder"></div>
-
-
-<h2 id="Recently published sponsored work">Recently published sponsored work <a href="{{ url_for('app.show_sponsor_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
-
-<table class="table table-hover" id="recently-published-sponsored-work"></table>
+<div id="sponsor-wembedder"></div>
 
 
-<h2 id="Authors on sponsored work">Authors on sponsored work</h2>
+<h2 id="recently-published-sponsored-work">Recently published sponsored work <a href="{{ url_for('app.show_sponsor_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<table class="table table-hover" id="authors-on-sponsored-work"></table>
+<table class="table table-hover" id="recently-published-sponsored-work-table"></table>
 
 
-<h2 id="Topics of sponsored work">Topics of sponsored work</h2>
+<h2 id="authors-on-sponsored-work">Authors on sponsored work</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<table class="table table-hover" id="authors-on-sponsored-work-table"></table>
+
+
+<h2 id="topics-of-sponsored-work">Topics of sponsored work</h2>
+
+<div id="topics-of-sponsored-work-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Ftopic%20%3FtopicLabel%0AWITH%20%7B%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Ftopic%0A%20%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP859%2B%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Ftopic%20.%0A%20%20%7D%20%0A%20%20GROUP%20BY%20%3Ftopic%0A%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%20%20LIMIT%20200%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20%7D%0A%7D%20%0AORDER%20BY%20DESC%28%3Fcount%29%0A"></iframe>
 </div>
 
     
 
-<h2 id="Co-sponsors">Co-sponsors</h2>
+<h2 id="co-sponsors">Co-sponsors</h2>
 
-<table class="table table-hover" id="co-sponsors"></table>
+<table class="table table-hover" id="co-sponsors-table"></table>
 
 
-<h2 id="Project budgets">Project budgets</h2>
+<h2 id="project-budgets">Project budgets</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="project-budgets-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AScatterChart%0ASELECT%20%3Fstart_time%20%3Fbudget%20%3Fproject%20%3FprojectLabel%20WHERE%20%7B%0A%20%20%3Fproject%20wdt%3AP859%2B%20wd%3A{{ q }}%20.%0A%20%20%3Fproject%20wdt%3AP2769%20%3Fbudget%20.%0A%20%20%3Fproject%20%28wdt%3AP580%20%7C%20wdt%3AP571%29%20%3Fstart_time%20.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D"></iframe>
 </div>
 

--- a/scholia/app/templates/taxon.html
+++ b/scholia/app/templates/taxon.html
@@ -62,33 +62,33 @@ WITH {
 
 
 {% block page_content %}
-<h1 id="h1">Taxon</h1>
+<h1 id="taxon">Taxon</h1>
 <script type="application/ld+json" id="bioschemas"></script>
 
-<div id="intro"></div>
+<div id="taxon-intro"></div>
 
-<div id="wembedder"></div>
-
-
-<h2 id="Parent Taxa">Parent Taxa</h2>
-
-<table class="table table-hover" id="parents"></table>
+<div id="taxon-wembedder"></div>
 
 
-<div class="embed-responsive embed-responsive-4by3">
+<h2 id="parent-taxa">Parent Taxa</h2>
+
+<table class="table table-hover" id="parent-taxa-table"></table>
+
+
+<div id="parent-taxa-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%0A%20%20%3Fchild%20%3FchildLabel%0A%20%20%3Frgb%20%0A%20%20%3Fparent%20%3FparentLabel%0AWITH%20%7B%0A%20%20SELECT%20%3Fchild%20%3Frgb%20%3Fparent%20WHERE%20%7B%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20%23%20Parent%20taxons%0A%20%20%20%20%20%20SELECT%20%3Fchild%20%3Frgb%20%3Fparent%20%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20SERVICE%20gas%3Aservice%20%7B%0A%20%20%20%20%20%20%20%20%20%20gas%3Aprogram%20gas%3AgasClass%20%22com.bigdata.rdf.graph.analytics.BFS%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Ain%20wd%3A{{ q }}%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20We%20should%20not%20do%20undirected%20here%20because%20this%20could%20result%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20in%20very%20big%20graphs.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AtraversalDirection%20%22Forward%22%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout%20%3Fchild%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout1%20%3Fdepth%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3Aout2%20%3Fparent1%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gas%3AlinkType%20wdt%3AP171%20%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%3Fchild%20wdt%3AP171%20%3Fparent%20.%0A%20%20%20%20%20%20%20%20BIND%28IF%28%3Fchild%20%3D%20wd%3A{{ q }}%2C%20%22FF0000%22%2C%20%22FFFFFF%22%29%20AS%20%3Frgb%29%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20UNION%20%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%23%20Child%20taxons%0A%20%20%20%20%20%20SELECT%20%3Fchild%20%3Frgb%20%3Fparent%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20BIND%28wd%3A{{ q }}%20AS%20%3Fparent%29%0A%20%20%20%20%20%20%20%20%3Fchild%20wdt%3AP171%20%3Fparent%20.%20%0A%20%20%20%20%20%20%20%20BIND%28%22DDDDDD%22%20AS%20%3Frgb%29%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20LIMIT%20100%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%20%0A%20%20%20%20%20%20%20%20%20%20%0A%20%20%3Fchild%20rdfs%3Alabel%20%3Fchild_label%20.%20FILTER%28LANG%28%3Fchild_label%29%20%3D%20%27en%27%29%0A%20%20%3Fparent%20rdfs%3Alabel%20%3Fparent_label%20.%20FILTER%28LANG%28%3Fparent_label%29%20%3D%20%27en%27%29%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Fchild%20wdt%3AP105%20%2F%20rdfs%3Alabel%20%3Fchild_rank_label%20.%20FILTER%20%28LANG%28%3Fchild_rank_label%29%20%3D%20%27en%27%29%0A%20%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Fparent%20wdt%3AP105%20%2F%20rdfs%3Alabel%20%3Fparent_rank_label%20.%20FILTER%20%28LANG%28%3Fparent_rank_label%29%20%3D%20%27en%27%29%0A%20%20%7D%0A%20%20BIND%28CONCAT%28%3Fchild_label%2C%20%22%20-%20%22%2C%20COALESCE%28%3Fchild_rank_label%2C%20%22%3F%3F%3F%22%29%29%20AS%20%3FchildLabel%29%0A%20%20BIND%28CONCAT%28%3Fparent_label%2C%20%22%20-%20%22%2C%20COALESCE%28%3Fparent_rank_label%2C%20%22%3F%3F%3F%22%29%29%20AS%20%3FparentLabel%29%0A%0A%7D"></iframe>
 </div>
 
 
 
-<h2 id="Genome">Genome</h2>
+<h2 id="genome">Genome</h2>
 
-<table class="table table-hover" id="genome"></table>
+<table class="table table-hover" id="genome-table"></table>
 
 
-<h2 id="Metabolome">Metabolome</h2>
+<h2 id="metabolome">Metabolome</h2>
 
-<table class="table table-hover" id="metabolome"></table>
+<table class="table table-hover" id="metabolome-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/taxon.html
+++ b/scholia/app/templates/taxon.html
@@ -67,7 +67,7 @@ WITH {
 
 <div id="taxon-intro"></div>
 
-<div id="taxon-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2 id="parent-taxa">Parent Taxa</h2>

--- a/scholia/app/templates/topic.html
+++ b/scholia/app/templates/topic.html
@@ -312,83 +312,82 @@ ORDER BY DESC(?count)
 
 {% block page_content %}
 
-<h1 id=h1>Topic</h1>
+<h1 id="topic">Topic</h1>
 
-<div id="intro"></div>
+<div id="topic-intro"></div>
 
-<div id="wembedder"></div>
+<div id="topic-wembedder"></div>
 
-<h2 id="Context">The topic in context</h2>
+<h2 id="context">The topic in context</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="context-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#PREFIX%20target%3A%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F{{ q }}%3E%0A%0A%23defaultView%3AGraph%0ASELECT%20%3Fnode%20%3FnodeLabel%20%3FnodeImage%20%3FchildNode%20%3FchildNodeLabel%20%3FchildNodeImage%20%3Frgb%20%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fproperty%20WHERE%20%7B%0A%20%20%20%20%20%20%3Fproperty%20a%20wikibase%3AProperty%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20wdt%3AP31%20wd%3AQ18610173%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20wdt%3AP31%20wd%3AQ26940804%20.%20%0A%20%20%20%20%7D%0A%7D%20AS%20%25properties%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fnode%20%3FchildNode%20WHERE%20%7B%0A%20%20%20%20%20%20BIND%28target%3A%20AS%20%3Fnode%29%0A%20%20%20%20%20%20%3Fnode%20%3Fp%20%3Fi.%0A%20%20%20%20%20%20%3FchildNode%20%3Fx%20%3Fp.%0A%20%20%20%20%20%20%3FchildNode%20rdf%3Atype%20wikibase%3AProperty.%0A%20%20%20%20%20%20FILTER%28STRSTARTS%28STR%28%3Fi%29%2C%20%22http%3A%2F%2Fwww.wikidata.org%2Fentity%2FQ%22%29%29%0A%20%20%20%20%20%20FILTER%28STRSTARTS%28STR%28%3FchildNode%29%2C%20%22http%3A%2F%2Fwww.wikidata.org%2Fentity%2FP%22%29%29%0A%20%20%20%20%7D%0A%20%20LIMIT%205000%0A%7D%20AS%20%25nodes%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3FchildNode%20%3Fnode%20%3Frgb%20WHERE%20%7B%0A%20%20%20%20%20%20BIND%28%22EFFBD8%22%20AS%20%3Frgb%29%0A%20%20%20%20%20%20target%3A%20%3Fp%20%3FchildNode.%0A%20%20%20%20%20%20%3Fnode%20%3Fx%20%3Fp.%0A%20%20%20%20%20%20%3Fnode%20rdf%3Atype%20wikibase%3AProperty.%0A%20%20%20%20%20%20FILTER%28STRSTARTS%28STR%28%3FchildNode%29%2C%20%22http%3A%2F%2Fwww.wikidata.org%2Fentity%2FQ%22%29%29%0A%20%20%20%20%7D%0A%20%20LIMIT%205000%0A%7D%20AS%20%25childNodes%0AWHERE%20%7B%0A%20%20%7B%0A%20%20%20%20INCLUDE%20%25nodes%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20INCLUDE%20%25childNodes%0A%20%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%0A%20%20%20%20INCLUDE%20%25properties%0A%20%20%20%20%3Fproperty%20wikibase%3AdirectClaim%20%3Fnodeclaim.%0A%20%20%20%20%3Fnode%20%3Fnodeclaim%20%3FnodeImage.%20%0A%20%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%0A%20%20%20%20INCLUDE%20%25properties%0A%20%20%20%20%3Fproperty%20wikibase%3AdirectClaim%20%3FchildNodeclaim.%0A%20%20%20%20%3FchildNode%20%3FchildNodeclaim%20%3FchildNodeImage.%20%0A%20%20%7D%0A%20%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%20%20%20%20%20%20%20%20%0A%7D"></iframe>
 </div>
 
-<h2 id="Recently published works on the topic">Recently published works on the topic <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
+<h2 id="recently-published-works">Recently published works on the topic <a href="{{ url_for('app.show_topic_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<table class="table table-hover" id="recently-published-works"></table>
+<table class="table table-hover" id="recently-published-works-table"></table>
 
 
-<h2 id="Publications per year">Publications per year</h2>
+<h2 id="publications-per-year">Publications per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="publications-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%0A%20%20%28STR%28%3Fyear_%29%20AS%20%3Fyear%29%0A%20%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_publications%29%0A%0A%20%20%23%20Work%20type%20used%20to%20color%20the%20bar%20chart%0A%20%20%3Ftype%0AWITH%20%7B%0A%20%20%23%20Find%20works%20with%20the%20topic.%20Also%20report%20the%20year%0A%20%20SELECT%0A%20%20%20%20%3Fwork%20%28MIN%28%3Fyears%29%20AS%20%3Fyear_%29%20%281%20AS%20%3Fdummy%29%20%28SAMPLE%28%3Farticle_type_%29%20AS%20%3Farticle_type%29%0A%20%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%2F%20%28wdt%3AP31%2a%2Fwdt%3AP279%2a%20%7C%20wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%29%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fdates%20.%0A%20%20%20%20BIND%28YEAR%28%3Fdates%29%20AS%20%3Fyears%29%20.%0A%0A%20%20%20%20%3Fwork%20wdt%3AP31%20%3Farticle_type_%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fwork%20%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear_%20WHERE%20%7B%0A%20%20%20%20%23%20default%20values%20%3D%200%0A%20%20%20%20%3Fyear_item%20wdt%3AP31%20wd%3AQ577%20.%20%0A%20%20%20%20%3Fyear_item%20wdt%3AP585%20%3Fdate%20.%0A%20%20%20%20BIND%28YEAR%28%3Fdate%29%20AS%20%3Fyear_%29%0A%20%20%7D%0A%7D%20AS%20%25default_counts%0AWITH%20%7B%0A%20%20%23%20Find%20earliest%20publication%20year%0A%20%20SELECT%20%28MIN%28%3Fyear_%29%20AS%20%3Fearliest_year%29%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fdummy%0A%7D%20AS%20%25earliest%20%20%0AWHERE%20%7B%0A%20%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Farticle_type%20rdfs%3Alabel%20%3Ftype%20.%20FILTER%20%28LANG%28%3Ftype%29%20%3D%20%22en%22%29%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20INCLUDE%20%25default_counts%0A%20%20%20%20BIND%28%22_%22%20AS%20%3Ftype%29%0A%20%20%7D%0A%20%20INCLUDE%20%25earliest%0A%20%20BIND%28YEAR%28NOW%28%29%29%20AS%20%3Fthis_year%29%0A%20%20FILTER%20%28%3Fyear_%20%3E%3D%20%3Fearliest_year%20%26%26%20%3Fyear_%20%3C%3D%20%3Fthis_year%20%26%26%20%3Fyear_%20%3E%3D%20YEAR%28%221900-01-01%22%5E%5Exsd%3AdateTime%29%29%0A%7D%0AGROUP%20BY%20%3Fyear_%20%3Ftype%0AORDER%20BY%20%3Fyear"></iframe>
 </div>
 
 
-<h2 id="Earliest published works on the topic">Earliest published works on the topic</h2>
+<h2 id="earliest-published-works">Earliest published works on the topic</h2>
 
-<table class="table table-hover" id="earliest-published-works"></table>
-
-
-<h2 id="Authors">Authors</h2>
+<table class="table table-hover" id="earliest-published-works-table"></table>
 
 
-<h3 id="Authors publishing about the topic">Authors publishing about the topic</h3>
+<h2 id="authors">Authors</h2>
 
-<table class="table table-hover" id="authors"></table>
 
-<h3 id="Co-author graph">Co-author graph</h3>
+<h3 id="authors-publishing-about-the-topic">Authors publishing about the topic</h3>
+
+<table class="table table-hover" id="authors-publishing-about-the-topic-table"></table>
+
+<h3 id="co-author-graph">Co-author graph</h3>
 
 The 25 most prolific authors and some of their key co-authors.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="co-author-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%20%3Fauthor1%20%3Fauthor1Label%20%3Frgb%20%3Fauthor2%20%3Fauthor2Label%0AWITH%20%7B%0A%20%20%23%20Find%20works%20with%20the%20topic%0A%20%20SELECT%20%3Fwork%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%2F%20%28wdt%3AP31%2a%20%2F%20wdt%3AP279%2a%20%7C%20wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%29%20wd%3A{{ q }}%20.%0A%20%20%7D%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20%23%20Limit%20the%20number%20of%20authors%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount1%29%20%3Fauthor1%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor1%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor1%0A%20%20ORDER%20BY%20DESC%28%3Fcount1%29%0A%20%20LIMIT%2025%0A%7D%20AS%20%25authors1%0AWITH%20%7B%0A%20%20%23%20Limit%20the%20number%20of%20coauthors%0A%20%20SELECT%20DISTINCT%20%3Fauthor2%20%3Fauthor1%20%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount2%29%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20INCLUDE%20%25authors1%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor1%20%2C%20%3Fauthor2%20.%0A%20%20%20%20FILTER%20%28%3Fauthor1%20%21%3D%20%3Fauthor2%29%20%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor2%20%3Fauthor1%20%0A%20%20ORDER%20BY%20DESC%28%3Fcount2%29%0A%20%20LIMIT%20250%0A%7D%20AS%20%25authors2%0AWHERE%20%7B%0A%23%20%20INCLUDE%20%25authors1%0A%20%20INCLUDE%20%25authors2%0A%20%20OPTIONAL%20%7B%20%3Fauthor1%20wdt%3AP21%20%3Fgender1%20.%20%7D%0A%20%20BIND%28%20IF%28%3Fgender1%20%3D%20wd%3AQ6581097%2C%20%223182BD%22%2C%20%22E6550D%22%29%20AS%20%3Frgb%29%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cfr%2Cde%2Cru%2Ces%2Czh%2Cjp%22.%0A%20%20%7D%0A%7D%0A"></iframe>
 </div>
 
 
-<h2 id="Topics">Topics</h2>
+<h2 id="topics">Topics</h2>
 
-<h3 id="Co-occurring topics">Co-occurring topics</h3>
+<h3 id="co-occurring-topics">Co-occurring topics</h3>
 
-<table class="table table-hover" id="topics"></table>
+<table class="table table-hover" id="co-occurring-topics-table"></table>
 
-<h3 id="Co-occurring topics graph">Co-occurring topics graph</h3>
+<h3 id="co-occurring-topics-graph">Co-occurring topics graph</h3>
 
 Only a maximum of the 400 most often occuring links are shown.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="co-occurring-topics-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%0A%20%20%3Ftopic1%20%3Ftopic1Label%20%3Ftopic2%20%3Ftopic2Label%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Ftopic1%20%3Ftopic2%0A%20%20WHERE%20%7B%0A%20%20%20%20%23%20Find%20works%20that%20are%20marked%20with%20main%20subject%20of%20the%20topic.%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%2F%20%28%20wdt%3AP31%2a%2Fwdt%3AP279%2a%20%7C%20wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%20%29%20wd%3A{{ q }}%20.%0A%20%20%20%20%0A%20%20%20%20%23%20Identify%20co-occuring%20topics.%20%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Ftopic1%2C%20%3Ftopic2%20.%20%0A%0A%20%20%20%20%23%20Exclude%20the%20topic%20it%20self%0A%20%20%20%20FILTER%20%28wd%3A{{ q }}%20%21%3D%20%3Ftopic1%20%26%26%20wd%3A{{ q }}%20%21%3D%20%3Ftopic2%20%26%26%20%3Ftopic1%20%21%3D%20%3Ftopic2%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic1%20%3Ftopic2%0A%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%0A%20%20%23%20There%20a%20performance%20problems%20in%20the%20browser%3A%20We%20cannot%20show%20large%20graphs%2C%0A%20%20%23%20so%20we%20put%20a%20limit%20on%20the%20number%20of%20links%20displayed.%0A%20%20LIMIT%20400%0A%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20%0A%20%20%23%20Label%20the%20results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%0A%20%20%7D%0A%7D%0A%0A"></iframe>
 </div>
 
-<h3 id="Co-occurring topics map">Co-occurring topics map</h3>
+<h3 id="co-occurring-topics-map">Co-occurring topics map</h3>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="co-occurring-topics-map-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%0ASELECT%0A%20%20%3Flocation%20%3FlocationLabel%0A%20%20%3Fgeo%0A%20%20%3Fexample_work%20%3Fexample_workLabel%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%3Flocation%20%3Fgeo%0A%20%20%20%20%28SAMPLE%28%3Fwork%29%20AS%20%3Fexample_work%29%0A%20%20WHERE%20%7B%0A%20%20%20%20%23%20Find%20works%20that%20are%20marked%20with%20main%20subject%20of%20the%20topic.%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%2F%20%28%20wdt%3AP31%2a%2Fwdt%3AP279%2a%20%7C%20wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%20%29%20wd%3A{{ q }}%20.%0A%20%20%20%20%0A%20%20%20%20%23%20Identify%20co-occuring%20topic%20that%20is%20geo-locatable.%20%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Flocation%20.%0A%20%20%20%20%3Flocation%20wdt%3AP625%20%3Fgeo%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Flocation%20%3Fgeo%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20%0A%20%20%23%20Label%20the%20results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%0A%20%20%7D%0A%7D%0A"></iframe>
 </div>
 
 
-
-<h2 id="Author score">Author score</h2>
+<h2 id="author-score">Author score</h2>
 
 Authors scored according to field of work, publications within the topic
 and citing works within the topic.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="author-score-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fscore%20%3Fauthor%20%3FauthorLabel%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%28SUM%28%3Fscore_%29%20AS%20%3Fscore%29%0A%20%20%20%20%3Fauthor%0A%20%20WHERE%20%7B%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20%3Fauthor%20wdt%3AP101%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20BIND%2820%20AS%20%3Fscore_%29%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%283%20AS%20%3Fscore_%29%20%3Fauthor%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20wdt%3AP921%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%281%20AS%20%3Fscore_%29%20%3Fauthor%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%3Fcited_work%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fcited_work%20.%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP921%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor%0A%7D%20AS%20%25results%20%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Cde%2Ces%2Cjp%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fscore%29%0ALIMIT%20200"></iframe>
 </div>
 
-<table class="table table-hover" id="author-score"></table>
+<table class="table table-hover" id="author-score-table"></table>
 
 Missing authors here?
 Then go to the
@@ -396,26 +395,26 @@ Then go to the
 page to resolve the author names.
 
 
-<h2 id="Venues and series publishing works about the topic">Venues and series publishing works about the topic</h2>
+<h2 id="venues-and-series-publishing-works">Venues and series publishing works about the topic</h2>
 
-<table class="table table-hover" id="venues"></table>
+<table class="table table-hover" id="venues-and-series-publishing-works-table"></table>
 
-<h2 id="Citations">Citations</h2>
+<h2 id="citations">Citations</h2>
 
-<h3 id="Works cited from works on the topic">Works cited from works on the topic</h3>
+<h3 id="top-cited">Works cited from works on the topic</h3>
 
-<table class="table table-hover" id="topCited"></table>
+<table class="table table-hover" id="top-cited-table"></table>
 
-<h3 id="Authors cited from works on the topic">Authors cited from works on the topic</h3>
+<h3 id="most-cited-authors">Authors cited from works on the topic</h3>
 
-<table class="table table-hover" id="most-cited-authors"></table>
+<table class="table table-hover" id="most-cited-authors-table"></table>
 
-<h3 id="Map-of-organizations">Map of organizations associated with works about the topic</h3>
+<h3 id="map-of-organizations">Map of organizations associated with works about the topic</h3>
 
 The colours indicate how many publications on the topic are associated with organizations in the given location, as detailed in the legend (top right).
 
-<div class="embed-responsive embed-responsive-4by3">
-    <iframe 
+<div id="map-of-organizations-iframe" class="embed-responsive embed-responsive-4by3">
+    <iframe
         class="embed-responsive-item" 
         src="https://query.wikidata.org/embed.html#%23defaultView%3AMap%0ASELECT%20%3Forganization%20%3ForganizationLabel%20%3Fgeo%20%3Fcount%20%3Flayer%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fwork%20WHERE%20%7B%0A%20%20%23%20Works%20on%20the%20topic%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%2F%20%28wdt%3AP361%2B%20%7C%20wdt%3AP1269%2B%20%7C%20%28wdt%3AP31%2a%20%2F%20wdt%3AP279%2a%29%20%29%20wd%3A{{ q }}%20.%0A%20%20%7D%0A%20%20LIMIT%2020000%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Forganization%20%3Fgeo%20%28COUNT%28DISTINCT%20%3Fwork%29%20AS%20%3Fcount%29%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%23%20Authors%20who%20have%20published%20works%20on%20the%20topic%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20.%20%0A%20%20%20%20%3Fauthor%20%28%20wdt%3AP108%20%7C%20wdt%3AP463%20%7C%20wdt%3AP1416%20%29%20%2F%20wdt%3AP361%2a%20%3Forganization%20.%20%0A%20%20%20%20%3Forganization%20wdt%3AP625%20%3Fgeo%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Forganization%20%3Fgeo%0A%20%20ORDER%20BY%20DESC%20%28%3Fcount%29%0A%20%20LIMIT%202000%0A%7D%20AS%20%25organizations%0AWHERE%20%7B%0A%20%20INCLUDE%20%25organizations%0A%20%20BIND%28IF%28%20%28%3Fcount%20%3C%201%29%2C%20%22No%20results%22%2C%20IF%28%28%3Fcount%20%3C%202%29%2C%20%221%20result%22%2C%20IF%28%28%3Fcount%20%3C%2011%29%2C%20%221%20%3C%20results%20%E2%89%A4%2010%22%2C%20IF%28%28%3Fcount%20%3C%20101%29%2C%20%2210%20%3C%20results%20%E2%89%A4%20100%22%2C%20IF%28%28%3Fcount%20%3C%201001%29%2C%20%22100%20%3C%20results%20%E2%89%A4%201000%22%2C%20IF%28%28%3Fcount%20%3C%2010001%29%2C%20%221000%20%3C%20results%20%E2%89%A4%2010000%22%2C%20%2210000%20or%20more%20results%22%29%20%29%20%29%20%29%20%29%29%20AS%20%3Flayer%20%29%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%20%20%20%20%20%20%20%20%0A%20%7D%0AORDER%20BY%20DESC%20%28%3Fcount%29%0A">
     </iframe>
@@ -423,11 +422,11 @@ The colours indicate how many publications on the topic are associated with orga
 
 
 
-<h3 id="Country-level-citation-graph">Citation graph of works about the topic, aggregated by country</h3>
+<h3 id="country-level-citation-graph">Citation graph of works about the topic, aggregated by country</h3>
 
 The graph indicates the countries associated with organizations whose authors have published works on the topic, and indicates the most cited countries (arrowheads) as well as the countries they are most frequently cited from.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="country-level-citation-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe 
         class="embed-responsive-item" 
         src="https://query.wikidata.org/embed.html#PREFIX%20target%3A%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F{{ q }}%3E%20%0A%0A%23defaultView%3AGraph%0ASELECT%20DISTINCT%20%3Fciting_country%20%3Fciting_countryLabel%20%3Fciting_flag%20%3Fcited_country%20%3Fcited_countryLabel%20%3Fcited_flag%0AWITH%20%7B%0A%20%20SELECT%20DISTINCT%20%3Fcited_country%20%3Fciting_country%20%28COUNT%28%3Fciting_country%29%20AS%20%3Fcount%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20WHERE%20%7B%0A%20%20%20%20%3Fciting_work%20wdt%3AP50%20%3Fciting_author%20.%20%0A%20%20%20%20%3Fciting_work%20wdt%3AP921%20target%3A%20.%0A%20%20%20%20%3Fcited_work%20wdt%3AP921%20target%3A%20.%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fcited_work%20.%20%0A%20%20%20%20%3Fcited_work%20wdt%3AP50%20%3Fcited_author%20.%20%20%0A%20%20%20%20FILTER%20%28%3Fciting_work%20%21%3D%20%3Fcited_work%29%0A%20%20%20%20FILTER%20NOT%20EXISTS%20%7B%0A%20%20%20%20%20%20%3Fciting_work%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fcited_work%20.%0A%20%20%20%20%20%20%3Fcited_work%20%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%20%20%7D%0A%20%20%20%20%3Fciting_author%20%28wdt%3AP108%7Cwdt%3AP1416%29%20%3Fciting_organization%20.%20%0A%20%20%20%20%3Fcited_author%20%28wdt%3AP108%7Cwdt%3AP1416%29%20%3Fcited_organization%20.%20%0A%20%20%20%20%3Fcited_organization%20wdt%3AP17%20%3Fcited_country.%0A%20%20%20%20%3Fciting_organization%20wdt%3AP17%20%3Fciting_country.%0A%20%20%20%20FILTER%20%28%3Fciting_country%20%21%3D%20%3Fcited_country%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fcited_country%20%3Fciting_country%0A%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%20%20LIMIT%2042%20%23%20Adjust%20number%20of%20connections%20to%20display%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20%3Fcited_country%20wdt%3AP41%20%3Fcited_flag%20.%20%0A%20%20%3Fciting_country%20wdt%3AP41%20%3Fciting_flag%20.%20%0A%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%20%20%20%20%20%20%20%20%0A%20%7D%0A">
@@ -435,9 +434,9 @@ The graph indicates the countries associated with organizations whose authors ha
 </div>
 
 
-<h3 id="Awards received by authors who published on the topic">Awards received by authors who published on the topic</h3>
+<h3 id="author-awards">Awards received by authors who published on the topic</h3>
 
-<table class="table table-hover" id="author-awards"></table>
+<table class="table table-hover" id="author-awards-table"></table>
 
 {% endblock %}
     

--- a/scholia/app/templates/topic.html
+++ b/scholia/app/templates/topic.html
@@ -316,7 +316,7 @@ ORDER BY DESC(?count)
 
 <div id="topic-intro"></div>
 
-<div id="topic-wembedder"></div>
+<div id="wembedder"></div>
 
 <h2 id="context">The topic in context</h2>
 

--- a/scholia/app/templates/topic_missing.html
+++ b/scholia/app/templates/topic_missing.html
@@ -174,35 +174,35 @@ ORDER BY DESC(?count) ?topics
 
 {% block page_content %}
 
-<h1 id="h1">Topic </h1>
+<h1 id="topic">Topic </h1>
 
 Missing information with respect to the topic <a href="{{ url_for('app.show_topic_empty') }}{{ q }}">{{ q }}</a>.
 
 
-<h2>Missing author items</h2>
+<h2 id="missing-author-items">Missing author items</h2>
 
 The authors listed below may only be represented as strings in Wikidata
 with no link to Wikidata items.
 Follow the link to use the Author disambiguator tool to try to resolve
 the authors.
 
-<table class="table table-hover" id="missing-author-items"></table>
+<table class="table table-hover" id="missing-author-items-table"></table>
 
-<h2>Missing publication date</h2>
+<h2 id="missing-pub-date">Missing publication date</h2>
 
 For the listed publications, Wikidata does not have publication dates.
-<table class="table table-hover" id="missing-pub-date"></table>
+<table class="table table-hover" id="missing-pub-date-table"></table>
 
 
-<h2>Missing publication venue</h2>
+<h2 id="missing-pub-venue">Missing publication venue</h2>
 
 For the listed publications, Wikidata does not have a statement as to where they were published.
-<table class="table table-hover" id="missing-pub-venue"></table>
+<table class="table table-hover" id="missing-pub-venue-table"></table>
 
 
-<h2>Works on the topic with missing additional topics</h2>
+<h2 id="missing-co-topic">Works on the topic with missing additional topics</h2>
 
 The following works have only been tagged with this one topic.
-<table class="table table-hover" id="missing-co-topic"></table>
+<table class="table table-hover" id="missing-co-topic-table"></table>
 
 {% endblock %}

--- a/scholia/app/templates/topics.html
+++ b/scholia/app/templates/topics.html
@@ -118,20 +118,20 @@ ORDER BY DESC(?score)
 
 {% block page_content %}
 
-<h1 id="h1">Topics</h1>
+<h1 id="topics">Topics</h1>
 
-<div id="intro"></div>
+<div id="topics-intro"></div>
 
-<table class="table table-hover" id="list-of-topics"></table>
+<table class="table table-hover" id="list-of-topics-table"></table>
 
-<h2>List of works on any combination of these topics</h2>
+<h2 id="list-of-works">List of works on any combination of these topics</h2>
 
-<table class="table table-hover" id="list-of-works"></table>
+<table class="table table-hover" id="list-of-works-table"></table>
 
 
-<h2>Authors</h2>
+<h2 id="authors">Authors</h2>
 
-<table class="table table-hover" id="authors"></table>
+<table class="table table-hover" id="authors-table"></table>
 
 
 

--- a/scholia/app/templates/use.html
+++ b/scholia/app/templates/use.html
@@ -71,45 +71,45 @@ ORDER BY DESC(?count)
 
 
 {% block page_content %}
-<h1 id="h1">Use</h1>
+<h1 id="use">Use</h1>
 
-<div id="intro"></div>
+<div id="use-intro"></div>
 
 <div id="wikiversity-extract"></div>
 
-<h2 id="Recent work using the resource">Recent work using the resource</h2>
+<h2 id="recent-work-using-the-used">Recent work using the resource</h2>
 
-<table class="table table-hover" id="recent-work-using-the-used"></table>
+<table class="table table-hover" id="recent-work-using-the-used-table"></table>
 
 
-<h2 id="Co-used">Co-usage</h2>
+<h2 id="co-used">Co-usage</h2>
 
 Resources used together.
 
-<table class="table table-hover" id="co-used"></table>
+<table class="table table-hover" id="co-used-table"></table>
 
 
-<h2 id="Topics of works using the resource">Topics of works using the
+<h2 id="topics-of-works-using-the-resource">Topics of works using the
   resource</h2>  
 
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="topics-of-works-using-the-resource-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Ftopic%20%3FtopicLabel%0AWITH%7B%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Ftopic%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20%28wdt%3AP2283%20%7C%20wdt%3AP4510%29%20%2F%20wdt%3AP279%2a%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Ftopic%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0A"></iframe>
 </div>
 
-<h2 id="Authors of works using the resource">Authors of works using
+<h2 id="authors-of-works-using-the-resource">Authors of works using
   the resource</h2> 
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="authors-of-works-using-the-resource-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fcount%20%3Fauthor%20%3FauthorLabel%0AWITH%7B%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Fauthor%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20%28wdt%3AP2283%20%7C%20wdt%3AP4510%29%20%2Fwdt%3AP279%2a%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29%0A"></iframe>
 </div>
 
 
-<h2>Usage over time</h2>
+<h2 id="usage-over-time">Usage over time</h2>
 
 Works using the resource over time.
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="usage-over-time-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%20%3Fyear%20%28COUNT%28%3Fwork%29%20AS%20%3Fnumber_of_works%29%20%3FuseLabel%0AWITH%7B%0A%20%20SELECT%0A%20%20%20%20%28MIN%28%3Fyear_%29%20AS%20%3Fyear%29%20%3Fwork%20%3Fuse%0A%20%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20%28wdt%3AP2283%20%7C%20wdt%3AP4510%29%20%3Fuse%20.%0A%20%20%20%20%3Fuse%20wdt%3AP279%2a%20wd%3A{{ q }}%20.%0A%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_datetime%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fpublication_datetime%29%29%20AS%20%3Fyear_%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fwork%20%3Fuse%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cnl%2Cno%2Cru%2Csv%2Czh%22%20.%20%7D%0A%7D%0AGROUP%20BY%20%3Fyear%20%3FuseLabel%0AORDER%20BY%20%3Fyear%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/use_empty.html
+++ b/scholia/app/templates/use_empty.html
@@ -65,9 +65,9 @@ Datasets:
 
 <h2>Overview</h2>
 
-<h3 id="most used software">Most used</h3>
+<h3 id="most-used">Most used</h3>
 
-<table class="table table-hover" id="most-used"></table>
+<table class="table table-hover" id="most-used-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/venue.html
+++ b/scholia/app/templates/venue.html
@@ -363,37 +363,37 @@ ORDER BY DESC(?date)
 
 
 {% block page_content %}
-<h1 id="h1">Venue</h1>
+<h1 id="venue">Venue</h1>
 
-<div id="intro"></div>
+<div id="venue-intro"></div>
 
-<div id="wembedder"></div>
-
-
-
-<h2>Recently published works <a href="{{ url_for('app.show_venue_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
-
-<table class="table table-hover" id="recently-published-works"></table>
-
-
-<h2 id="Topics">Topics</h2>
-
-<table class="table table-hover" id="topics"></table>
+<div id="venue-wembedder"></div>
 
 
 
-<h2 id="Authors">Authors</h3>
+<h2 id="recently-published-works">Recently published works <a href="{{ url_for('app.show_venue_empty') }}{{ q }}/latest-works/rss"><img height="24" width="48" src="{{ url_for('static', filename='images/rss-40674_320.png') }}" alt="RSS icon" /></a></h2>
 
-<h3 id="Author images">Author images</h2>
+<table class="table table-hover" id="recently-published-works-table"></table>
 
-<div class="embed-responsive embed-responsive-4by3">
+
+<h2 id="topics">Topics</h2>
+
+<table class="table table-hover" id="topics-table"></table>
+
+
+
+<h2 id="authors">Authors</h3>
+
+<h3 id="author-images">Author images</h2>
+
+<div id="author-images-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AImageGrid%0ASELECT%20%28SAMPLE%28%3Fimage_%29%20AS%20%3Fimage%29%20%3Fauthor%20%3FauthorLabel%20%3Fcount%0AWITH%20%7B%0A%20%20SELECT%20%3Fauthor%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP1433%20wd%3A{{ q }}%3B%0A%20%20%20%20%20%20%20%20%20%20wdt%3AP50%20%3Fauthor%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor%0A%7D%20AS%20%25authors%0AWHERE%20%7B%0A%20%20INCLUDE%20%25authors%0A%20%20%3Fauthor%20wdt%3AP18%20%3Fimage_%20.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cjp%2Cnl.no%2Cru%2Csv%2Czh%22%20.%20%7D%20%0A%7D%0AGROUP%20BY%20%3Fauthor%20%3FauthorLabel%20%3Fcount%0AORDER%20BY%20DESC%28%3Fcount%29%0ALIMIT%2050%20%20"></iframe>
 </div>
 
 
-<h3 id="Prolific authors">Prolific authors</h3>
+<h3 id="prolific-authors">Prolific authors</h3>
 
-<table class="table table-hover" id="prolific-authors"></table>
+<table class="table table-hover" id="prolific-authors-table"></table>
 
 Missing authors here?
 Then go to the
@@ -401,28 +401,28 @@ Then go to the
 page to resolve the author names.
 
 
-<h3 id="Co-author graph">Co-author graph</h3>
+<h3 id="co-author-graph">Co-author graph</h3>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="co-author-graph-iframe" class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%20%3Fauthor1%20%3Fauthor1Label%20%3Frgb%20%3Fauthor2%20%3Fauthor2Label%0AWITH%20%7B%0A%20%20%23%20Find%20works%20published%20in%20the%20given%20venue%0A%20%20SELECT%20%3Fwork%20WHERE%20%7B%0A%20%20%20%20%3Fwork%20wdt%3AP1433%20wd%3A{{ q }}%20.%0A%20%20%7D%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20%23%20Limit%20the%20number%20of%20authors%0A%20%20SELECT%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount1%29%20%3Fauthor1%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor1%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor1%0A%20%20ORDER%20BY%20DESC%28%3Fcount1%29%0A%20%20LIMIT%2015%0A%7D%20AS%20%25authors1%0AWITH%20%7B%0A%20%20%23%20Limit%20the%20number%20of%20coauthors%0A%20%20SELECT%20DISTINCT%20%3Fauthor2%20%3Fauthor1%20%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount2%29%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20INCLUDE%20%25authors1%0A%20%20%20%20%3Fwork%20wdt%3AP50%20%3Fauthor1%20%2C%20%3Fauthor2%20.%0A%20%20%20%20FILTER%20%28%3Fauthor1%20%21%3D%20%3Fauthor2%29%20%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fauthor2%20%3Fauthor1%20%0A%20%20ORDER%20BY%20DESC%28%3Fcount2%29%0A%20%20LIMIT%20150%0A%7D%20AS%20%25authors2%0AWHERE%20%7B%0A%23%20%20INCLUDE%20%25authors1%0A%20%20INCLUDE%20%25authors2%0A%20%20OPTIONAL%20%7B%20%3Fauthor1%20wdt%3AP21%20%3Fgender1%20.%20%7D%0A%20%20BIND%28%20IF%28%3Fgender1%20%3D%20wd%3AQ6581097%2C%20%223182BD%22%2C%20%22E6550D%22%29%20AS%20%3Frgb%29%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cfr%2Cde%2Cru%2Ces%2Czh%2Cjp%22.%0A%20%20%7D%0A%7D%0A"></iframe>
 </div>
 
 
-<h2 id="Citations">Citations</h2>
+<h2 id="citations">Citations</h2>
 
-<h3 id="Most cited articles"
+<h3 id="most-cited-articles"
     title="Most cited articles published in the venue, where the citations may come from any venue">Most cited articles</h3>
 
-<table class="table table-hover" id="most-cited-works"></table>
+<table class="table table-hover" id="most-cited-articles-table"></table>
 
-<h3 id="Most cited authors"
+<h3 id="most-cited-authors"
     title="Most cited authors based on articles published in the venue and where citations may come from any venue">Most cited authors</h3>
 
-<table class="table table-hover" id="most-cited-authors"></table>
+<table class="table table-hover" id="most-cited-authors-table"></table>
 
-<h3 id="Citation distribution">Citation distribution</h2>
+<h3 id="citation-distribution">Citation distribution</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="citation-distribution-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0Aselect%20%3Fnumber_of_citations%20%28count%28%3Fwork%29%20as%20%3Fcount%29%20where%20%7B%0A%20%20%7B%0A%20%20%20%20SELECT%20%3Fwork%20%28COUNT%28%3Fciting_work%29%20AS%20%3Fnumber_of_citations%29%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20%3Fwork%20wdt%3AP1433%20wd%3A{{ q }}.%20%20%20%0A%20%20%20%20%20%20optional%20%7B%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fwork%20%0A%20%20%7D%0A%7D%20%0Agroup%20by%20%3Fnumber_of_citations%0Aorder%20by%20desc%28%3Fnumber_of_citations%29%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/venue.html
+++ b/scholia/app/templates/venue.html
@@ -367,7 +367,7 @@ ORDER BY DESC(?date)
 
 <div id="venue-intro"></div>
 
-<div id="venue-wembedder"></div>
+<div id="wembedder"></div>
 
 
 

--- a/scholia/app/templates/venue.html
+++ b/scholia/app/templates/venue.html
@@ -428,38 +428,38 @@ page to resolve the author names.
 
 
 
-<h3 id="Cited venues">Cited venues</h3>
+<h3 id="cited-venues">Cited venues</h3>
 
-<table class="table table-hover" id="cited-venues"></table>
-
-
-<h3 id="Venues cited from">Venues cited from</h3>
-
-<table class="table table-hover" id="citing-venues"></table>
+<table class="table table-hover" id="cited-venues-table"></table>
 
 
-<h2>Articles citing retracted articles</h2>
+<h3 id="citing-venues">Venues cited from</h3>
 
-<table class="table table-hover" id="articles-citing-retractions"></table>
+<table class="table table-hover" id="citing-venues-table"></table>
+
+
+<h2 id="articles-citing-retractions">Articles citing retracted articles</h2>
+
+<table class="table table-hover" id="articles-citing-retractions-table"></table>
 
 
 <h2>Gender distribution</h2>
 
 
-<h3>Authors</h3>
+<h3 id="author-gender-distributione">Authors</h3>
 
 Distinct authors.
 
-<table class="table table-hover" id="gender-distribution"></table>
+<table class="table table-hover" id="gender-distribution-table"></table>
 
-<h3>Authorships</h3>
+<h3 id="authorship-gender-distribution">Authorships</h3>
 
-<table class="table table-hover" id="authorships-gender-distribution"></table>
+<table class="table table-hover" id="authorships-gender-distribution-table"></table>
 
 
-<h2 id="AuthorAwards">Author Awards</h2>
+<h2 id="author-awards">Author Awards</h2>
 
-<table class="table table-hover" id="author-awards"></table>
+<table class="table table-hover" id="Author-awards-table"></table>
 
 {% endblock %}
     

--- a/scholia/app/templates/venue_missing.html
+++ b/scholia/app/templates/venue_missing.html
@@ -82,21 +82,21 @@ ORDER BY DESC(?count) ?topics
 
 
 {% block page_content %}
-<h1 id="h1">Venue</h1>
+<h1 id="venue">Venue</h1>
 
-<h2>Missing author item</h2>
+<h2 id="missing-author-item">Missing author item</h2>
 
 If there are any author names listed below, it means that these name strings have not been matched to Wikidata items for at least some of the works published in the venue.
 
 Follow the link to use the Author disambiguator tool to try to create links between the work items and the respective author items.
 
-<table class="table table-hover" id="missing-author-item"></table>
+<table class="table table-hover" id="missing-author-item-table"></table>
 
-<h2>Missing topics</h2>
+<h2 id="missing-topics">Missing topics</h2>
 
 The following highly cited articles have few or no "main subject" statements.
 
-<table class="table table-hover" id="missing-topics"></table>
+<table class="table table-hover" id="missing-topics-table"></table>
 
 
 {% endblock %}

--- a/scholia/app/templates/venues.html
+++ b/scholia/app/templates/venues.html
@@ -40,32 +40,32 @@ $(document).ready(function() {
 
 {% block page_content %}
 
-<h1 id="h1">Venues</h1>
+<h1 id="venues">Venues</h1>
 
-<div id="intro"></div>
-
-
-<table class="table table-hover" id="list-of-venues"></table>
+<div id="venues-intro"></div>
 
 
+<table class="table table-hover" id="list-of-venues-table"></table>
 
-<h2 id="Published works per year">Published works per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+
+<h2 id="published-works-per-year">Published works per year</h2>
+
+<div id="published-works-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%20%3Fyear%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Fvenue%20%3FvenueLabel%20WHERE%20%7B%0A%20%20VALUES%20%3Fvenue%20%7B%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%7D%0A%20%20%3Fwork%20wdt%3AP1433%20%3Fvenue%20.%0A%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_datetime%20.%20%0A%20%20BIND%28STR%28YEAR%28%3Fpublication_datetime%29%29%20AS%20%3Fyear%29%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%7D%0AGROUP%20BY%20%3Fyear%20%3Fvenue%20%3FvenueLabel%0AORDER%20BY%20%3Fyear%0A%0A"></iframe>
 </div>
 
 
-<h2 id="Citations per year">Citations per year</h2>
+<h2 id="citations-per-year">Citations per year</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="citations-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%20%3Fyear%20%3Fcount%20%3Fvenue%20%3FvenueLabel%20%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%20%3Fvenue%20%0A%20%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Fvenue%20%7B%20%20%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%20%20%7D%0A%20%20%20%20%3Fwork%20wdt%3AP1433%20%3Fvenue%20.%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fpublication_datetime%20.%0A%20%20BIND%28STR%28YEAR%28%3Fpublication_datetime%29%29%20AS%20%3Fyear%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear%20%3Fvenue%0A%7D%20AS%20%25result%0AWHERE%20%7B%0A%20%20INCLUDE%20%25result%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20%3Fyear%0A%0A"></iframe>
 </div>
 
 
-<h2 id="Citations to work ratio">Citations to work ratio</h2>
+<h2 id="citations-to-work-ratio">Citations to work ratio</h2>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="citations-to-work-ratio-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%20%3Fyear%20%28%3Fcitation_count%20%2F%20%3Fwork_count%20AS%20%3Fcitations_to_works_ratio%29%20%3Fvenue%20%3FvenueLabel%20%0AWITH%20%7B%0A%20%20SELECT%20%3Fwork%20%3Fvenue%0A%20%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Fvenue%20%7B%20%20%20%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%20%20%20%7D%0A%20%20%20%20%3Fwork%20wdt%3AP1433%20%3Fvenue%20.%0A%20%20%7D%0A%7D%20AS%20%25works%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear%20%28COUNT%28%3Fwork%29%20AS%20%3Fwork_count%29%20%3Fvenue%20%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fwork%20wdt%3AP577%20%3Fpublication_datetime%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fpublication_datetime%29%29%20AS%20%3Fyear%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear%20%3Fvenue%0A%7D%20AS%20%25work_counts%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear%20%28COUNT%28%3Fwork%29%20AS%20%3Fcitation_count%29%20%3Fvenue%20%0A%20%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25works%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork%20.%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fpublication_datetime%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fpublication_datetime%29%29%20AS%20%3Fyear%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear%20%3Fvenue%0A%7D%20AS%20%25citation_counts%0AWHERE%20%7B%0A%20%20INCLUDE%20%25work_counts%0A%20%20INCLUDE%20%25citation_counts%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Ces%2Cfr%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20%3Fyear%0A%0A"></iframe>
 </div>
 

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -217,7 +217,7 @@ Topics based on a weighting between main subject of work, cited and citing works
 
 <h3 id="related-works-kg" title="Wembedder knowledge graph embedding related works">Related works from knowledge graph embedding</h3>
 
-<div id="related-works-kg-wembedder"></div>
+<div id="wembedder"></div>
 
 
 <h2>Citations</h2>

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -202,57 +202,57 @@ Topics based on a weighting between main subject of work, cited and citing works
 </div>
 
 
-<h2>Timeline</h2>
+<h2 id="timeline">Timeline</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="timeline-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ATimeline%0ASELECT%20DISTINCT%20%3Fdatetime%20%3Fdescription%20WHERE%20%7B%0A%20%20%7B%0A%20%20%20%20wd%3A{{ q }}%20wdt%3AP577%20%3Fdatetime%20.%0A%20%20%20%20BIND%28%22%F0%9F%8C%9E%20publication%20date%22%20AS%20%3Fdescription%29%0A%20%20%7D%0A%20%20UNION%20%0A%20%20%7B%0A%20%20%20%20wd%3A{{ q }}%20wdt%3AP2507%20%2F%20wdt%3AP577%20%3Fdatetime%20.%0A%20%20%20%20BIND%28%22%E2%9D%97%20erratum%22%20AS%20%3Fdescription%29%0A%20%20%7D%0A%20%20UNION%20%0A%20%20%7B%0A%20%20%20%20wd%3A{{ q }}%20wdt%3AP5824%20%2F%20wdt%3AP577%20%3Fdatetime%20.%0A%20%20%20%20BIND%28%22%E2%9B%94%20retracted%22%20AS%20%3Fdescription%29%0A%20%20%7D%0A%20%20UNION%20%0A%20%20%7B%0A%20%20%20%20wd%3A{{ q }}%20p%3AP793%20%3Fevent_statement%20.%0A%20%20%20%20%3Fevent_statement%20ps%3AP793%20%3Fevent_type%20.%0A%20%20%20%20%3Fevent_type%20rdfs%3Alabel%20%3Fdescription_%20.%0A%20%20%20%20%3Fevent_statement%20pq%3AP585%20%3Fdatetime%20.%0A%20%20%20%20FILTER%20%28LANG%28%3Fdescription_%29%20%3D%20%22en%22%29%0A%20%20%20%20%0A%20%20%20%20%23%20Warning%20icon%20for%20retraction%0A%20%20%20%20BIND%28%0A%20%20%20%20%20%20IF%28%0A%20%20%20%20%20%20%20%20%3Fevent_type%20%3D%20wd%3AQ45203135%2C%0A%20%20%20%20%20%20%20%20CONCAT%28%22%E2%9B%94%20%22%2C%20%3Fdescription_%29%2C%0A%20%20%20%20%20%20%20%20IF%28%0A%20%20%20%20%20%20%20%20%20%20%3Fevent_type%20%3D%20wd%3AQ56478588%2C%0A%20%20%20%20%20%20%20%20%20%20CONCAT%28%22%E2%9D%93%20%22%2C%20%3Fdescription_%29%2C%0A%20%20%20%20%20%20%20%20%20%20%3Fdescription_%0A%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%29%20AS%20%3Fdescription%29%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20SELECT%20%3Fdatetime%20%3Fdescription%20WHERE%20%7B%0A%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP2860%20%2F%20wdt%3AP577%20%3Fdatetime%0A%20%20%20%20%20%20BIND%28%22%F0%9F%93%96%E2%9E%A1%EF%B8%8F%20cited%20work%20with%20earliest%20publication%20date%22%20AS%20%3Fdescription%29%0A%20%20%20%20%7D%0A%20%20%20%20ORDER%20BY%20%3Fdatetime%0A%20%20%20%20LIMIT%201%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20SELECT%20%3Fdatetime%20%3Fdescription%20WHERE%20%7B%0A%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP2860%20%2F%20wdt%3AP577%20%3Fdatetime%0A%20%20%20%20%20%20BIND%28%22%F0%9F%93%96%E2%9E%A1%EF%B8%8F%20cited%20work%20with%20latest%20publication%20date%22%20AS%20%3Fdescription%29%0A%20%20%20%20%7D%0A%20%20%20%20ORDER%20BY%20DESC%28%3Fdatetime%29%0A%20%20%20%20LIMIT%201%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20SELECT%20%3Fdatetime%20%3Fdescription%20WHERE%20%7B%0A%20%20%20%20%20%20wd%3A{{ q }}%20%5Ewdt%3AP2860%20%2F%20wdt%3AP577%20%3Fdatetime%0A%20%20%20%20%20%20BIND%28%22%F0%9F%93%96%E2%AC%85%EF%B8%8F%20citing%20work%20with%20earliest%20publication%20date%22%20AS%20%3Fdescription%29%0A%20%20%20%20%7D%0A%20%20%20%20ORDER%20BY%20%3Fdatetime%0A%20%20%20%20LIMIT%201%0A%20%20%7D%0A%20%20UNION%0A%20%20%7B%0A%20%20%20%20SELECT%20%3Fdatetime%20%3Fdescription%20WHERE%20%7B%0A%20%20%20%20%20%20wd%3A{{ q }}%20%5Ewdt%3AP2860%20%2F%20wdt%3AP577%20%3Fdatetime%0A%20%20%20%20%20%20BIND%28%22%F0%9F%93%96%E2%AC%85%EF%B8%8F%20citing%20work%20with%20latest%20publication%20date%22%20AS%20%3Fdescription%29%0A%20%20%20%20%7D%0A%20%20%20%20ORDER%20BY%20DESC%28%3Fdatetime%29%0A%20%20%20%20LIMIT%201%0A%20%20%7D%0A%20%20%20%20UNION%0A%20%20%7B%0A%20%20%20%20wd%3A{{ q }}%20%28wdt%3AP747%20%7C%20%5Ewdt%3AP629%29%20%2F%20wdt%3AP577%20%3Fdatetime%0A%20%20%20%20BIND%28%22%F0%9F%8C%9E%20Publication%20of%20edition%22%20AS%20%3Fdescription%29%0A%20%20%7D%0A%7D"></iframe>
 </div>
 
 <h2>Related works</h2>
 
-<h3 title="List of related works by co-citation analysis.">Related works from co-citation analysis</h3>
+<h3 id="related-works" title="List of related works by co-citation analysis.">Related works from co-citation analysis</h3>
 
-<table class="table table-hover" id="related-works"></table>
+<table class="table table-hover" id="related-works-table"></table>
 
 
-<h3 title="Wembedder knowledge graph embedding related works">Related works from knowledge graph embedding</h3>
+<h3 id="related-works-kg" title="Wembedder knowledge graph embedding related works">Related works from knowledge graph embedding</h3>
 
-<div id="wembedder"></div>
+<div id="related-works-kg-wembedder"></div>
 
 
 <h2>Citations</h2>
 
 
-<h3>Citations to the work</h3>
+<h3 id="citations-to-the-work">Citations to the work</h3>
 
 Recent citations to the work
 
-<table class="table table-hover" id="citations-to-the-work"></table>
+<table class="table table-hover" id="citations-to-the-work-table"></table>
 
 
-<h3>Cited works</h3>
+<h3 id="cited-works">Cited works</h3>
 
-<table class="table table-hover" id="cited-works"></table>
-
-
-<h3>Authors of cited works</h3>
-
-<table class="table table-hover" id="cited-works-authors"></table>
+<table class="table table-hover" id="cited-works-table"></table>
 
 
-<h3 title="Partial citation graph around the work with the up to 40 most important works displayed">Citation graph</h3>
+<h3 id="cited-works-authors">Authors of cited works</h3>
+
+<table class="table table-hover" id="cited-works-authors-table"></table>
+
+
+<h3 id="citation-graph" title="Partial citation graph around the work with the up to 40 most important works displayed">Citation graph</h3>
 
 
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="citation-graph-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3AGraph%0ASELECT%0A%20%20%3Fciting_work%20%3Fciting_workLabel%20%3Frgb%20%0A%20%20%3Fcited_work%20%3Fcited_workLabel%0AWITH%20%7B%20%0A%20%20SELECT%20%28COUNT%28%2a%29%20AS%20%3Fcount%29%20%3Fciting_work%20WHERE%20%7B%0A%20%20%20%20wd%3A{{ q }}%20%28%5Ewdt%3AP2860%20%7C%20wdt%3AP2860%29%20%2F%20%28%5Ewdt%3AP2860%20%7C%20wdt%3AP2860%29%3F%20%3Fciting_work%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fciting_work%0A%20%20ORDER%20BY%20DESC%28%3Fcount%29%0A%20%20LIMIT%2040%0A%7D%20AS%20%25citing_works%0AWITH%20%7B%20%0A%20%20SELECT%20%28COUNT%28%2a%29%20AS%20%3Fcount_%29%20%3Fcited_work%20WHERE%20%7B%0A%20%20%20%20wd%3A{{ q }}%20%28%5Ewdt%3AP2860%20%7C%20wdt%3AP2860%29%20%2F%20%28%5Ewdt%3AP2860%20%7C%20wdt%3AP2860%29%3F%20%3Fcited_work%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fcited_work%0A%20%20ORDER%20BY%20DESC%28%3Fcount_%29%0A%20%20LIMIT%2040%0A%7D%20AS%20%25cited_works%0AWITH%20%7B%0A%20%20SELECT%20%28MAX%28%3Fcount%29%20AS%20%3Fmax_count%29%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25citing_works%0A%20%20%20%20BIND%281%20AS%20%3Fdummy%29%0A%20%20%7D%20%0A%20%20GROUP%20BY%20%3Fdummy%0A%7D%20AS%20%25max_count%0AWHERE%20%7B%0A%20%20INCLUDE%20%25citing_works%0A%20%20INCLUDE%20%25max_count%0A%20%20INCLUDE%20%25cited_works%0A%20%20%0A%20%20%3Fciting_work%20wdt%3AP2860%20%3Fcited_work%20.%0A%20%20%0A%20%20BIND%28STR%28xsd%3Ainteger%2899%20%2a%20%281%20-%20%3Fcount%20%2F%20%3Fmax_count%29%29%29%20AS%20%3Fgrey%29%0A%20%20BIND%28CONCAT%28SUBSTR%28%220%22%2C%201%2C%202%20-%20STRLEN%28%3Fgrey%29%29%2C%20%3Fgrey%29%20AS%20%3Fpadded_grey%29%0A%20%20BIND%28CONCAT%28%3Fpadded_grey%2C%20%3Fpadded_grey%2C%20%3Fpadded_grey%29%20AS%20%3Frgb%29%0A%0A%20%20%7B%20%0A%20%20%20%20%20%20%3Fciting_work%20%28p%3AP50%29%20%3Fciting_author_statement%20.%20%0A%20%20%20%20%20%20%3Fciting_author_statement%20pq%3AP1545%20%221%22%20.%0A%20%20%20%20%20%20%3Fciting_author_statement%20ps%3AP50%20%3Fciting_author%20.%0A%20%20%20%20%20%20%3Fciting_author%20rdfs%3Alabel%20%3Fciting_author_name%20.%0A%20%20%20%20%20%20filter%28lang%28%3Fciting_author_name%29%20%3D%20%27en%27%29%0A%20%20%20%20%7D%0A%20%20%20%20union%20%0A%20%20%09%7B%20%0A%20%20%20%20%20%20%3Fciting_work%20%28p%3AP2093%29%20%3Fciting_author_statement%20.%20%0A%20%20%20%20%20%20%3Fciting_author_statement%20pq%3AP1545%20%221%22%20.%0A%20%20%20%20%20%20%3Fciting_author_statement%20ps%3AP2093%20%3Fciting_author_name%20.%0A%20%20%20%20%7D%0A%20%20%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20%3Fcited_work%20%28p%3AP50%29%20%3Fcited_author_statement%20.%20%0A%20%20%20%20%20%20%3Fcited_author_statement%20pq%3AP1545%20%221%22%20.%0A%20%20%20%20%20%20%3Fcited_author_statement%20ps%3AP50%20%3Fcited_author%20.%0A%20%20%20%20%20%20%3Fcited_author%20rdfs%3Alabel%20%3Fcited_author_name%20.%0A%20%20%20%20%20%20filter%28lang%28%3Fcited_author_name%29%20%3D%20%27en%27%29%0A%20%20%20%20%7D%0A%20%20%20%20union%20%0A%20%20%09%7B%20%0A%20%20%20%20%20%20%3Fcited_work%20%28p%3AP2093%29%20%3Fcited_author_statement%20.%20%0A%20%20%20%20%20%20%3Fcited_author_statement%20pq%3AP1545%20%221%22%20.%0A%20%20%20%20%20%20%3Fcited_author_statement%20ps%3AP2093%20%3Fcited_author_name%20.%0A%20%20%20%20%7D%0A%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fciting_date%20.%20%0A%20%20%20%20%3Fcited_work%20wdt%3AP577%20%3Fcited_date%20.%20%0A%20%20%20%20bind%28year%28%3Fciting_date%29%20as%20%3Fciting_year%29%0A%20%20%20%20bind%28year%28%3Fcited_date%29%20as%20%3Fcited_year%29%0A%20%20%20%20bind%28concat%28%3Fciting_author_name%2C%20%22%2C%20%22%2C%20str%28%3Fciting_year%29%29%20as%20%3Fciting_workLabel%29%0A%20%20%20%20bind%28concat%28%3Fcited_author_name%2C%20%22%2C%20%22%2C%20str%28%3Fcited_year%29%29%20as%20%3Fcited_workLabel%29%0A%7D%0AORDER%20BY%20DESC%28%3Fcount%29"></iframe>
 </div>
 
 
-<h3 id="Citations-per-year"
+<h3 id="citations-per-year"
     title="Number of citations to the work per year">Citations per year</h3>
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="citations-per-year-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABarChart%0ASELECT%0A%20%20%28STR%28%3Fyear_%29%20AS%20%3Fyear%29%0A%20%20%28SUM%28%3Fcount_%29%20AS%20%3Fcount%29%0A%20%20%3Fkind%0AWHERE%20%7B%0A%20%20%7B%0A%20%20%20%20VALUES%20%3Fyear_%20%7B%202000%202001%202002%202003%202004%202005%202006%202007%202008%202009%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%202010%202011%202012%202013%202014%202015%202016%202017%202018%202019%20%7D%0A%20%20%20%20BIND%280%20AS%20%3Fcount_%29%0A%20%20%20%20BIND%28%22_%22%20AS%20%3Fkind%29%0A%20%20%7D%0A%20%20UNION%20%0A%20%20%7B%0A%20%20%20%20SELECT%0A%20%20%20%20%20%20%3Fyear_%0A%20%20%20%20%20%20%28COUNT%28DISTINCT%20%3Fciting_work%29%20AS%20%3Fcount_%29%0A%20%20%20%20%20%20%3Fkind%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20%3Fciting_work%20wdt%3AP2860%20wd%3A{{ q }}%20.%0A%20%20%0A%20%20%20%20%20%20%23%20Detect%20self-citations%0A%20%20%20%20%20%20BIND%28IF%28EXISTS%20%7B%20wd%3A{{ q }}%20wdt%3AP50%20%3Fselfauthor%20.%20%3Fciting_work%20%20wdt%3AP50%20%3Fselfauthor%20%7D%20%2C%0A%20%20%20%20%20%20%20%20%22detected%20incoming%20self-citations%22%2C%0A%20%20%20%20%20%20%20%20%22citations%20from%20others%20or%20non-detected%20self-citations%22%29%20AS%20%3Fkind%29%0A%0A%20%20%20%20%20%20%23%20Year%20of%20citation%0A%20%20%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fdate%20.%0A%20%20%20%20%20%20BIND%28YEAR%28%3Fdate%29%20AS%20%3Fyear_%29%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fyear_%20%3Fkind%0A%20%20%7D%0A%20%20UNION%20%0A%20%20%7B%0A%20%20%20%20SELECT%0A%20%20%20%20%20%20%3Fyear_%0A%20%20%20%20%20%20%28COUNT%28DISTINCT%20%3Fcited_work%29%20AS%20%3Fcount_%29%0A%20%20%20%20%20%20%3Fkind%0A%20%20%20%20WHERE%20%7B%0A%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP2860%20%3Fcited_work%20.%0A%20%20%0A%20%20%20%20%20%20%23%20Detect%20self-citations%0A%20%20%20%20%20%20BIND%28IF%28EXISTS%20%7B%20%3Fcited_work%20wdt%3AP50%20%3Fselfauthor%20.%20wd%3A{{ q }}%20wdt%3AP50%20%3Fselfauthor%20%7D%2C%0A%20%20%20%20%20%20%20%20%22detected%20outgoing%20self-citations%22%2C%0A%20%20%20%20%20%20%20%20%22outgoing%20citations%20to%20others%20or%20non-detected%20self-citations%22%29%20AS%20%3Fkind%29%0A%0A%20%20%20%20%20%20%23%20Year%20of%20citation%0A%20%20%20%20%20%20%3Fcited_work%20wdt%3AP577%20%3Fdate%20.%0A%20%20%20%20%20%20BIND%28YEAR%28%3Fdate%29%20AS%20%3Fyear_%29%0A%20%20%20%20%7D%0A%20%20%20%20GROUP%20BY%20%3Fyear_%20%3Fkind%0A%20%20%7D%0A%7D%0AGROUP%20BY%20%3Fyear_%20%3Fkind%0AORDER%20BY%20DESC%28%3Fyear_%29%20"></iframe>
 </div>
 

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -179,25 +179,25 @@ ORDER BY DESC(?cited_works)
 
 
 {% block page_content %}
-<h1 id="h1">Work</h1>
+<h1 id="work">Work</h1>
 
-<div id="intro"></div>
+<div id="work-intro"></div>
 
-<div id="details"></div>
+<div id="work-details"></div>
 
 
 <!-- h2>List of authors</h2 -->
 
-<table class="table table-hover" id="list-of-authors"></table>
+<table class="table table-hover" id="list-of-authors-table"></table>
 
 Are authors missing here? You can help curate them via the <a href="https://author-disambiguator.toolforge.org/work_item.php?id={{ q }}
 &doit=Get+author+links+for+work">Author Disambiguator page for this work</a>.
 
-<h2>Topic scores</h2>
+<h2 id="topic-scores">Topic scores</h2>
 
 Topics based on a weighting between main subject of work, cited and citing works.
 
-<div class="embed-responsive embed-responsive-16by9">
+<div id="topic-scores-iframe" class="embed-responsive embed-responsive-16by9">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%20%3Fscore%20%3Ftopic%20%3FtopicLabel%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%28SUM%28%3Fscore_%29%20AS%20%3Fscore%29%0A%20%20%20%20%3Ftopic%0A%20%20WHERE%20%7B%0A%20%20%20%20%7B%20%0A%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP921%20%3Ftopic%20.%0A%20%20%20%20%20%20BIND%2820%20AS%20%3Fscore_%29%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%20%0A%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP921%2Fwdt%3AP279%20%3Ftopic%20.%0A%20%20%20%20%20BIND%283%20AS%20%3Fscore_%29%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%23%20Topic%20of%20a%20cited%20work%0A%20%20%20%20%20%20wd%3A{{ q }}%20wdt%3AP2860%2Fwdt%3AP921%20%3Ftopic%20.%0A%20%20%20%20%20%20BIND%281%20AS%20%3Fscore_%29%0A%20%20%20%20%7D%0A%20%20%20%20UNION%0A%20%20%20%20%7B%0A%20%20%20%20%20%20SELECT%20%281%20AS%20%3Fscore_%29%20%3Ftopic%20WHERE%20%7B%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP2860%20wd%3A{{ q }}%20.%0A%20%20%20%20%20%20%20%20%3Fciting_work%20wdt%3AP921%20%3Ftopic%20.%20%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic%0A%7D%20AS%20%25results%20%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Cde%2Ces%2Cjp%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fscore%29%0ALIMIT%20200"></iframe>
 </div>
 

--- a/scholia/app/templates/work_empty.html
+++ b/scholia/app/templates/work_empty.html
@@ -78,9 +78,9 @@ Scientific articles, conference articles, books, ...
 
 <div class="container">
 
-    <h2>Recently retracted works</h2>
+    <h2 id="recentrly-retracted-works">Recently retracted works</h2>
 
-    <table class="table table-hover" id="recently-retracted-works"></table>
+    <table class="table table-hover" id="recently-retracted-works-table"></table>
     
 </div>    
 

--- a/scholia/app/templates/works.html
+++ b/scholia/app/templates/works.html
@@ -94,36 +94,36 @@ ORDER BY DESC(?count) DESC(?date)
 
 {% block page_content %}
 
-<h1 id="h1">Works</h1>
+<h1 id="works">Works</h1>
 
-<div id="intro"></div>
-
-
-<table class="table table-hover" id="list-of-works"></table>
+<div id="works-intro"></div>
 
 
-<h2>Authors</h2>
-
-<table class="table table-hover" id="authors"></table>
+<table class="table table-hover" id="list-of-works-table"></table>
 
 
-<h2>Topics</h2>
+<h2 id="authors">Authors</h2>
 
-<div class="embed-responsive embed-responsive-4by3">
+<table class="table table-hover" id="authors-table"></table>
+
+
+<h2 id="topics">Topics</h2>
+
+<div id="topics-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ABubbleChart%0ASELECT%0A%20%20%3Fcount%0A%20%20%3Ftopic%20%3FtopicLabel%0AWITH%20%7B%0A%20%20SELECT%0A%20%20%20%20%28COUNT%28%3Fwork%29%20AS%20%3Fcount%29%0A%20%20%20%20%3Ftopic%20%0A%20%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Fwork%20%7B%20%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%20%7D%0A%20%20%20%20%3Fwork%20wdt%3AP921%20%3Ftopic%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Ftopic%0A%20%20ORDER%20BY%20%3Fcount%20%20%0A%20%20LIMIT%20200%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%20%20%20%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cda%2Cde%2Ces%2Cfr%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%20%20%7D%0AORDER%20BY%20DESC%28%3Fcount%29"></iframe>
 </div>
 
 
-<h2 id="Citations">Citations</h2>
+<h2 id="citations">Citations</h2>
 
 <h3>Citing works</h3>
 
-<table class="table table-hover" id="citing-works"></table>
+<table class="table table-hover" id="citing-works-table"></table>
 
 
-<h3>Citations per year</h3>
+<h3 id="citations-per-year">Citations per year</h3>
 
-<div class="embed-responsive embed-responsive-4by3">
+<div id="citations-per-year-iframe" class="embed-responsive embed-responsive-4by3">
     <iframe class="embed-responsive-item" src="https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%20%3Fyear%20%3Fnumber_of_citations%20%3Fwork%20%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear%20%28COUNT%28DISTINCT%20%3Fciting_work%29%20AS%20%3Fnumber_of_citations%29%20%3Fwork1%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Fwork1%20%7B%20%20%20{% for q in qs %} wd:{{ q }} {% endfor %}%20%20%20%7D%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork1%20.%0A%0A%20%20%20%20%23%20Year%20of%20citation%20%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fdate%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fdate%29%29%20AS%20%3Fyear%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear%20%3Fwork1%0A%7D%20AS%20%25counts%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear%20%3Fnumber_of_citations%20%3Fwork1%20%28SAMPLE%28%3Fwork1Labels%29%20AS%20%3Fwork1Label%29%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25counts%0A%20%20%20%20%3Fwork1%20rdfs%3Alabel%20%3Fwork1Labels%20.%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear%20%3Fnumber_of_citations%20%3Fwork1%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20BIND%28CONCAT%28%3Fwork1Label%2C%20%22%20%28%22%2C%20SUBSTR%28STR%28%3Fwork1%29%2C%2032%29%2C%20%22%29%22%29%20AS%20%3Fwork%29%20%0A%7D%0A" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>https://query.wikidata.org/embed.html#%23defaultView%3ALineChart%0ASELECT%20%3Fyear%20%3Fnumber_of_citations%20%3Fwork%20%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear%20%28COUNT%28%3Fciting_work%29%20AS%20%3Fnumber_of_citations%29%20%3Fwork1%20WHERE%20%7B%0A%20%20%20%20VALUES%20%3Fwork1%20%7B%20%20%20%20%7D%0A%20%20%20%20%3Fciting_work%20wdt%3AP2860%20%3Fwork1%20.%0A%0A%20%20%20%20%23%20Year%20of%20citation%20%0A%20%20%20%20%3Fciting_work%20wdt%3AP577%20%3Fdate%20.%0A%20%20%20%20BIND%28STR%28YEAR%28%3Fdate%29%29%20AS%20%3Fyear%29%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear%20%3Fwork1%0A%7D%20AS%20%25counts%0AWITH%20%7B%0A%20%20SELECT%20%3Fyear%20%3Fnumber_of_citations%20%3Fwork1%20%3Fwork1Label%20WHERE%20%7B%0A%20%20%20%20INCLUDE%20%25counts%0A%20%20%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%2Cda%2Ces%2Cfr%2Cnl%2Cno%2Cru%2Csv%2Czh%22.%20%7D%0A%20%20%7D%0A%20%20GROUP%20BY%20%3Fyear%20%3Fnumber_of_citations%20%3Fwork1%20%3Fwork1Label%0A%7D%20AS%20%25results%0AWHERE%20%7B%0A%20%20INCLUDE%20%25results%0A%20%20%3Fwork1%20rdfs%3Alabel%20%3Fwork1Label%20.%20%20%23%20Dummy%20line%20to%20get%20%3Fwork1Label%20evaluated%0A%20%20BIND%28CONCAT%28%3Fwork1Label%2C%20%22%20%28%22%2C%20SUBSTR%28STR%28%3Fwork1%29%2C%2032%29%2C%20%22%29%22%29%20AS%20%3Fwork%29%20%0A%7D%0A"></iframe>
 </div>
 


### PR DESCRIPTION
Dear all,

Please check this pull request as it resolves issue #1157 

All (26 templates with 60-70 HTML files) sections headings, tables and iframes were provided with proper IDs that complies with W3's CSS naming conventions:
[https://www.w3.org/TR/CSS2/syndata.html#characters](https://www.w3.org/TR/CSS2/syndata.html#characters)

Thank you.

Sincerely,
Ammar