### PR TITLE
Update Toolforge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Scholia is a python package and webapp for interaction with scholarly informatio
 Webapp
 ------
 
-As a webapp, it currently runs from `Wikimedia Tool Labs`_, a facility provided by the `Wikimedia Foundation`_. It is accessible from
+As a webapp, it currently runs from `Wikimedia Toolforge`_, a facility provided by the `Wikimedia Foundation`_. It is accessible from
 
     https://scholia.toolforge.org/
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ See file `CONTRIBUTING.rst`_ for technical details on how to improve Scholia.
 
 .. _Wikidata: https://www.wikidata.org
 .. _Wikimedia Foundation: https://wikimediafoundation.org
-.. _Wikimedia Tool Labs: https://tools.wmflabs.org/
+.. _Wikimedia Toolforge: https://toolforge.org/
 .. _launch Scholia via Gitpod: https://gitpod.io/#https://github.com/fnielsen/scholia
 .. _CONTRIBUTING.rst: https://github.com/fnielsen/scholia/blob/master/CONTRIBUTING.rst
 .. _requirements.txt: https://github.com/fnielsen/scholia/blob/master/requirements.txt

--- a/scholia/__main__.py
+++ b/scholia/__main__.py
@@ -15,7 +15,7 @@ Examples
 
 References
 ----------
-  https://tools.wmflabs.org/wikidata-todo/quick_statements.php
+  https://wikidata-todo.toolforge.org/quick_statements.php
 
 """
 

--- a/scholia/app/templates/arxiv_to_quickstatements.html
+++ b/scholia/app/templates/arxiv_to_quickstatements.html
@@ -42,7 +42,7 @@ ID is found in Wikidata. However, note that new items may not be immediately fou
 
 <div id="quickstatements"><pre>{{ quickstatements }} </pre></div>
 
-<a href="https://tools.wmflabs.org/wikidata-todo/quick_statements.php?list={{ quickstatements | urlencode }}">Forward to Magnus Manske's quickstatements</a>
+<a href="https://wikidata-todo.toolforge.org/quick_statements.php?list={{ quickstatements | urlencode }}">Forward to Magnus Manske's quickstatements</a>
 
 {% endif %}
 

--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -393,9 +393,9 @@ div>
     {% if first_initial and last_name %}
     <a href="https://query.wikidata.org/#select%20%2a%20where%20%7B%20%3Fwork%20wdt%3AP2093%20%3Fauthorname%20.%20filter%28regex%28%3Fauthorname%2C%20%27%5E{{ first_initial | urlencode }}.%2b{{ last_name | urlencode }}%24%27%29%29%20%7D%20limit%201">Search for unlinked works on Wikidata</a>
     or
-    add new ones with <a href="https://tools.wmflabs.org/sourcemd/">sourcemd</a>.
+    add new ones with <a href="https://sourcemd.toolforge.org/">sourcemd</a>.
     {% else %}
-    Add new ones with <a href="https://tools.wmflabs.org/sourcemd/">sourcemd</a>.
+    Add new ones with <a href="https://sourcemd.toolforge.org/">sourcemd</a>.
     {% endif %}
     
 </div -->

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -69,7 +69,7 @@
 
 	 try {
 	     var hashtag = item.claims.P2572[0].mainsnak.datavalue.value;
-	     detailsList.push( '<a href="https://tools.wmflabs.org/hashtags-hub/' +
+	     detailsList.push( '<a href="https://hashtags-hub.toolforge.org/' +
 			       encodeURI( hashtag ) + '">#' + escapeHTML( hashtag ) + '</a> ');
 	 }
 	 catch(e) {}
@@ -267,7 +267,7 @@
 
 
      /* Wembedder */
-     var wembedderUrl = "https://tools.wmflabs.org/wembedder/api/most-similar/{{ q }}";
+     var wembedderUrl = "https://wembedder.toolforge.org/api/most-similar/{{ q }}";
      $.ajax({
 	 url: wembedderUrl,
 	 success: function (data) {
@@ -475,7 +475,7 @@
     Code from
     <a href="https://github.com/fnielsen/scholia">GitHub repository</a>
     |
-    Hosted on   <a href="https://tools.wmflabs.org/">Wikimedia Toolforge</a>,
+    Hosted on   <a href="https://toolforge.org/">Wikimedia Toolforge</a>,
     a <a href="https://wikimediafoundation.org">Wikimedia Foundation</a> service
     |
     License for content: CC0 for data, CC-BY-SA for text and media

--- a/scholia/app/templates/faq.html
+++ b/scholia/app/templates/faq.html
@@ -22,7 +22,7 @@
 	    sourcemd is currently disabled.
 	
 	If you want to include a scientific document in Wikidata and it has a DOI, PMID or PMCID identifier
-	then you can use Magnus Manske's <a href="https://tools.wmflabs.org/sourcemd/">sourcemd tool</a>
+	then you can use Magnus Manske's <a href="https://sourcemd.toolforge.org/">sourcemd tool</a>
 	(you need a Wikidata account and authorize Manske's tool to edit in Wikidata).
 	If you want to update some information about an author and the
 	author has an ORCID profile with public works, 

--- a/scholia/app/templates/lexeme.html
+++ b/scholia/app/templates/lexeme.html
@@ -39,7 +39,7 @@ SELECT DISTINCT ?work ?workLabel ?workDescription {
     <a title="View lexeme in Ordia"
        role="button"
        class="btn btn-outline-dark btn-sm"
-       href="https://tools.wmflabs.org/ordia/{{ lexeme }}">Ordia 🔗</a>
+       href="https://ordia.toolforge.org/{{ lexeme }}">Ordia 🔗</a>
 </p>
 
 <h1 id="h1">Lexeme</h1>

--- a/scholia/app/templates/pathway.html
+++ b/scholia/app/templates/pathway.html
@@ -135,7 +135,7 @@ $(document).ready(function() {
     if ("wpid" in dataValues) {
       const pathwayViewerIFrameResults = $.find("#pathway-viewer > iframe");
       pathwayViewerIFrameResults.every(function(pathwayViewerIFrameResult) {
-        pathwayViewerIFrameResult.setAttribute("src", `https://tools.wmflabs.org/pathway-viewer/?id=${dataValues.wpid}`);
+        pathwayViewerIFrameResult.setAttribute("src", `https://pathway-viewer.toolforge.org/?id=${dataValues.wpid}`);
       });
       pathwayViewerSection.style.display = "";
     }

--- a/scholia/arxiv.py
+++ b/scholia/arxiv.py
@@ -143,7 +143,7 @@ def metadata_to_quickstatements(metadata):
 
     References
     ----------
-    - https://tools.wmflabs.org/wikidata-todo/quick_statements.php
+    - https://wikidata-todo.toolforge.org/quick_statements.php
 
     """
     qs = u"CREATE\n"

--- a/scholia/scrape/nips.py
+++ b/scholia/scrape/nips.py
@@ -26,7 +26,7 @@ listed at https://papers.nips.cc/. It will return a JSON with a list of URLs
 for the individual papers.
 
 The generated quickstatements from `paper-url-to-quickstatements` can be
-submitted to https://tools.wmflabs.org/quickstatements/.
+submitted to https://quickstatements.toolforge.org/.
 
 """
 


### PR DESCRIPTION
Changed links to other Toolforge tools to use toolforge.org and changed Tool Labs to Toolforge in the README file