### PR TITLE
Implement short author name #549

### DIFF
--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -12,19 +12,39 @@ SELECT
   ?order
 
   # Author item and label
-  ?author ?authorLabel
-
-  # Either show the ORCID iD or construct part of a URL to search on the ORCID homepage
-  (COALESCE(?orcid_, CONCAT("orcid-search/quick-search/?searchQuery=", ENCODE_FOR_URI(?authorLabel))) AS ?orcid)
+  ?author ?authorUrl ?authorDescription
+  
+  ?orcid
 WHERE {
-  wd:{{ q }} p:P50 ?author_statement .
-  ?author_statement ps:P50 ?author .
-  OPTIONAL {
-    ?author_statement pq:P1545 ?order_ .
-    BIND(xsd:integer(?order_) AS ?order)
+  {
+    wd:{{ q }} p:P50 ?author_statement .
+    ?author_statement ps:P50 ?author_ .
+    ?author_ rdfs:label ?author .
+    FILTER (LANG(?author) = 'en')
+    BIND(CONCAT("../author/", SUBSTR(STR(?author_), 32)) AS ?authorUrl)
+    OPTIONAL {
+      ?author_statement pq:P1545 ?order_ .
+      BIND(xsd:integer(?order_) AS ?order)
+    }
+    OPTIONAL { ?author_ wdt:P496 ?orcid_ . }
+    # Either show the ORCID iD or construct part of a URL to search on the ORCID homepage
+    BIND(COALESCE(?orcid_, CONCAT("orcid-search/quick-search/?searchQuery=", ENCODE_FOR_URI(?author))) AS ?orcid)
+    OPTIONAL {
+      ?author_ schema:description ?authorDescription .
+      FILTER (LANG(?authorDescription) = "en")
+    }
   }
-  OPTIONAL { ?author wdt:P496 ?orcid_ . }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,nl,no,ru,sv,zh". }
+  UNION
+  {
+    wd:{{ q }} p:P2093 ?authorstring_statement .
+    ?authorstring_statement ps:P2093 ?author_
+    BIND(CONCAT("UNRESOLVED: ", ?author_) AS ?author)
+    OPTIONAL {
+      ?authorstring_statement pq:P1545 ?order_ .
+      BIND(xsd:integer(?order_) AS ?order)
+    }
+    BIND(CONCAT("https://author-disambiguator.toolforge.org/?doit=Look+for+author&name=", ENCODE_FOR_URI(?author_)) AS ?authorUrl)
+  }
 }
 ORDER BY ?order
 `
@@ -191,7 +211,7 @@ ORDER BY DESC(?cited_works)
 <table class="table table-hover" id="list-of-authors"></table>
 
 Are authors missing here? You can help curate them via the <a href="https://author-disambiguator.toolforge.org/work_item.php?id={{ q }}
-&doit=Get+author+links+for+work">Author Disambiguator page for this work</a>.
+								    &doit=Get+author+links+for+work">Author Disambiguator page for this work</a>.
 
 <h2>Topic scores</h2>
 


### PR DESCRIPTION
Let author table in work aspect show the short author name.
A link is created to the author-disambiguator.
Description is also added.