### PR TITLE
quick fix for the author disambiguator link

### DIFF
--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -285,8 +285,7 @@ ORDER BY DESC(?cited_works)
 
 <table class="table table-hover" id="list-of-authors"></table>
 
-Are authors missing here? You can help curate them via the <a href="https://author-disambiguator.toolforge.org/work_item.php?id={{ q }}
-								    &doit=Get+author+links+for+work">Author Disambiguator page for this work</a>.
+Are authors missing here? You can help curate them via the <a href="https://author-disambiguator.toolforge.org/work_item.php?id={{ q }}&doit=Get+author+links+for+work">Author Disambiguator page for this work</a>.
 
 <h2>Topic scores</h2>
 


### PR DESCRIPTION
Fix a URL formatting error introduced in https://github.com/fnielsen/scholia/commit/58c8575790be55d257b0b2306a93fc5fd58128aa when fixing https://github.com/fnielsen/scholia/issues/1177 .