### PR TITLE
Add links from multiple authors and topics

### DIFF
--- a/scholia/app/templates/author.html
+++ b/scholia/app/templates/author.html
@@ -38,16 +38,22 @@ ORDER BY DESC(?date)
 
  venueStatisticsSparql = `
 # Venue statistics for a specific author
-SELECT ?count (SAMPLE(?short_name_) AS ?short_name) ?venue ?venueLabel ?topics
+SELECT
+  ?count (SAMPLE(?short_name_) AS ?short_name)
+  ?venue ?venueLabel
+  ?topics ?topicsUrl
 WITH {
   SELECT
     (COUNT(DISTINCT ?work) as ?count)
     ?venue
-    (GROUP_CONCAT(DISTINCT ?topic; separator=" // ") AS ?topics)
+    (GROUP_CONCAT(DISTINCT ?topic_label; separator=", ") AS ?topics)
+    (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic), 32); separator=",")) AS ?topicsUrl)
   WHERE {
 	  ?work wdt:P50 wd:{{ q }} .
     ?work wdt:P1433 ?venue .
-    OPTIONAL { ?venue wdt:P921 / rdfs:label ?topic . FILTER(LANG(?topic) = 'en') }
+    OPTIONAL {
+      ?venue wdt:P921 ?topic .
+      ?topic rdfs:label ?topic_label . FILTER(LANG(?topic_label) = 'en') }
   }
   GROUP BY ?venue
 } AS %result
@@ -56,7 +62,7 @@ WHERE {
   OPTIONAL { ?venue wdt:P1813 ?short_name_ . }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh". }  
 } 
-GROUP BY ?count ?venue ?venueLabel ?topics
+GROUP BY ?count ?venue ?venueLabel ?topics ?topicsUrl
 ORDER BY DESC(?count)
  `
 

--- a/scholia/app/templates/authors.html
+++ b/scholia/app/templates/authors.html
@@ -20,10 +20,18 @@ WHERE {
 }
 `
 
-  listOfJointlyAuthoredWorksSparql = `
-SELECT ?coauthor_count ?work ?workLabel ?authors
+ listOfJointlyAuthoredWorksSparql = `
+SELECT
+  ?coauthor_count
+  ?work ?workLabel
+  ?authors ?authorsUrl
 WITH {
-  SELECT (COUNT(?author) AS ?coauthor_count) ?work (GROUP_CONCAT(?author_label; separator=" // ") AS ?authors) WHERE {
+  SELECT 
+    (COUNT(?author) AS ?coauthor_count)
+    ?work 
+    (GROUP_CONCAT(?author_label; separator=", ") AS ?authors)
+    (GROUP_CONCAT(SUBSTR(STR(?author), 32); separator=",") AS ?authorsUrl)
+  {
     VALUES ?author { {% for q in qs %} wd:{{ q }} {% endfor %} }
     ?work wdt:P50 ?author .
     OPTIONAL { ?author rdfs:label ?author_label . FILTER(LANG(?author_label) = 'en') }

--- a/scholia/app/templates/event_series.html
+++ b/scholia/app/templates/event_series.html
@@ -93,7 +93,7 @@ ORDER BY DESC(?score)
 LIMIT 200
 `
 
-  personsSparql = `
+ personsSparql = `
 SELECT
   ?number_of_roles
   # (?number_of_publications AS ?works)
@@ -219,26 +219,42 @@ LIMIT 500
 
  proceedingsPublicationsSparql = `
 SELECT
+  ?date
   ?work ?workLabel
-  ?authors
-  ?topics
+  ?authors ?authorsUrl
+  ?topics ?topicsUrl
 WITH {
-  SELECT 
+  SELECT
+    (MIN(?date_) AS ?date) 
     ?work
-    (GROUP_CONCAT(DISTINCT ?author; separator=" // ") AS ?authors)
-    (GROUP_CONCAT(DISTINCT ?topic; separator=" // ") AS ?topics)
+    (GROUP_CONCAT(DISTINCT ?author_label; separator=", ") AS ?authors)
+    (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)
+    (GROUP_CONCAT(DISTINCT ?topic_label; separator=", ") AS ?topics)
+    (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic), 32); separator=",")) AS ?topicsUrl)
   WHERE {
     ?work wdt:P1433 / wdt:P4745 / (wdt:P179 | wdt:P31) wd:{{ q }} .
-    OPTIONAL { ?work wdt:P50 / rdfs:label ?author . FILTER(LANG(?author) = "en") }
-    OPTIONAL { ?work wdt:P921 / rdfs:label ?topic . FILTER(LANG(?topic) = "en") }
+    OPTIONAL {
+      ?work wdt:P577 ?publication_datetime .
+      BIND(xsd:date(?publication_datetime) AS ?date_)
+    }
+    OPTIONAL {
+      ?work wdt:P50 ?author .
+      ?author rdfs:label ?author_label . FILTER(LANG(?author_label) = "en")
+    }
+    OPTIONAL {
+      ?work wdt:P921 ?topic .
+      ?topic rdfs:label ?topic_label . FILTER(LANG(?topic_label) = "en")
+    }
   }
   GROUP BY ?work
+  ORDER BY DESC(?date)
+  LIMIT 500
 } AS %results
 WHERE {
   INCLUDE %results
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 }
-
+ORDER BY DESC(?date)
 `
 
 

--- a/scholia/app/templates/venue.html
+++ b/scholia/app/templates/venue.html
@@ -10,7 +10,8 @@
 SELECT
   (MIN(?publication_date_) AS ?publication_date)
   ?work ?workLabel
-  (GROUP_CONCAT(?author_label; separator=" // ") AS ?authors)
+  (GROUP_CONCAT(?author_label; separator=", ") AS ?authors)
+  (CONCAT("../authors/", GROUP_CONCAT(SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)
 WHERE {
   ?work wdt:P1433 wd:{{ q }} .
   OPTIONAL {
@@ -18,7 +19,8 @@ WHERE {
     BIND(xsd:date(?publication_datetime) AS ?publication_date_)
   }
   OPTIONAL {
-    ?work wdt:P50/rdfs:label ?author_label .
+    ?work wdt:P50 ?author .
+    ?author rdfs:label ?author_label .
     FILTER (LANG(?author_label) = 'en')
   }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,da,de,es,fr,jp,nl,no,ru,sv,zh" . } 
@@ -77,7 +79,7 @@ WHERE {
 ORDER BY DESC(?count)
 LIMIT 50
  `
-  coAuthorsSparql = `
+ coAuthorsSparql = `
 #defaultView:Graph
 SELECT ?author1 ?author1Label ?rgb ?author2 ?author2Label
 WITH {
@@ -120,7 +122,7 @@ WHERE {
 
   `
 
-  citedVenuesSparql = `
+ citedVenuesSparql = `
 # Cited venues from specific journal
 SELECT
   ?count


### PR DESCRIPTION
Som columns that displayed multiple authors and topics did not
link to the authors or topics aspects. Now some of these cases
have been linked.
This relates to #1214 and #1215