### PR TITLE
Implement search on DOI #1234

### DIFF
--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -274,8 +274,8 @@ SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel WHERE {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "da.wikipedia.org" ;
                         wikibase:api "Search" ;
-                        mwapi:srsearch "{{ q }}" ;
-                        mwapi:srlimit "max" .
+                        mwapi:srsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:srlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
       }
       BIND(URI(CONCAT("https://da.wikipedia.org/wiki/", ENCODE_FOR_URI(?title_))) AS ?titleUrl)
@@ -288,8 +288,8 @@ SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel WHERE {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "en.wikipedia.org" ;
                         wikibase:api "Search" ;
-                        mwapi:srsearch "{{ q }}" ;
-                        mwapi:srlimit "max" .
+                        mwapi:srsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:srlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
       }
       BIND(URI(CONCAT("https://en.wikipedia.org/wiki/", ENCODE_FOR_URI(?title_))) AS ?titleUrl)

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -15,7 +15,7 @@ from ..arxiv import get_metadata as get_arxiv_metadata
 from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
                      github_to_qs,
                      inchikey_to_qs, issn_to_qs, orcid_to_qs, viaf_to_qs,
-                     q_to_class, random_author, twitter_to_qs,
+                     q_to_class, q_to_dois, random_author, twitter_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,
                      lipidmaps_to_qs, ror_to_qs, wikipathways_to_qs,
                      pubchem_to_qs, atomic_number_to_qs, ncbi_taxon_to_qs,
@@ -1879,7 +1879,11 @@ def show_work(q):
         Rendered HTML page for specific work.
 
     """
-    return render_template('work.html', q=q)
+    try:
+        dois = q_to_dois(q)
+    except Exception:
+        dois = []
+    return render_template('work.html', q=q, dois=dois)
 
 
 @main.route('/work/')

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -589,6 +589,41 @@ def mesh_to_qs(meshid):
             for item in data['results']['bindings']]
 
 
+def q_to_dois(q):
+    """Get DOIs for a Q item.
+
+    Query the Wikidata Query Service to get zero or more DOIs for a particular
+    Q item identified by the Q identifier.
+
+    Parameters
+    ----------
+    q : str
+        String with Wikidata Q identifier.
+
+    Returns
+    -------
+    dois : list of str
+        List with zero or mores strings each containing a DOI.
+
+    Examples
+    --------
+    >>> dois = q_to_dois("Q87191917")
+    >>> dois == ['10.1016/S0140-6736(20)30211-7']
+    True
+
+    """
+    query = """SELECT ?doi {{ wd:{q} wdt:P356 ?doi }}""".format(q=q)
+
+    url = 'https://query.wikidata.org/sparql'
+    params = {'query': query, 'format': 'json'}
+    response = requests.get(url, params=params, headers=HEADERS)
+    data = response.json()
+
+    results = data['results']['bindings']
+    dois = [result['doi']['value'] for result in results]
+    return dois
+
+
 def q_to_label(q, language='en'):
     """Get label for Q item.
 


### PR DESCRIPTION
The Wikipedia mention table now also search on DOI for Wikipedia citations.
This require a server-side query to get the DOI to get a list of DOIs.
The extra query seems not to delay the generation of the table too much.