### PR TITLE
Fix #1238 link authors and topics

### DIFF
--- a/scholia/app/templates/event.html
+++ b/scholia/app/templates/event.html
@@ -127,19 +127,28 @@ LIMIT 200
 `
 
  proceedingsPublicationsSparql = `
+# Scholia
 SELECT
   ?work ?workLabel
-  ?authors
-  ?topics
+  ?authors ?authorsUrl
+  ?topics ?topicsUrl
 WITH {
   SELECT 
     ?work
-    (GROUP_CONCAT(DISTINCT ?author; separator=" // ") AS ?authors)
-    (GROUP_CONCAT(DISTINCT ?topic; separator=" // ") AS ?topics)
+    (GROUP_CONCAT(DISTINCT ?author_label; separator=", ") AS ?authors)
+    (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?author), 32); separator=",")) AS ?authorsUrl)    
+    (GROUP_CONCAT(DISTINCT ?topic_label; separator=", ") AS ?topics)
+    (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic), 32); separator=",")) AS ?topicsUrl)
   WHERE {
     ?work wdt:P1433 / wdt:P4745 wd:{{ q }} .
-    OPTIONAL { ?work wdt:P50 / rdfs:label ?author . FILTER(LANG(?author) = "en") }
-    OPTIONAL { ?work wdt:P921 / rdfs:label ?topic . FILTER(LANG(?topic) = "en") }
+    OPTIONAL {
+      ?work wdt:P50 ?author .
+      ?author rdfs:label ?author_label . FILTER(LANG(?author_label) = "en")
+    }
+    OPTIONAL {
+      ?work wdt:P921 ?topic .
+      ?topic rdfs:label ?topic_label . FILTER(LANG(?topic_label) = "en")
+    }
   }
   GROUP BY ?work
 } AS %results
@@ -147,7 +156,6 @@ WHERE {
   INCLUDE %results
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
 }
-
 `
 
  recentPublicationsSparql = `


### PR DESCRIPTION
Authors and topics in the proceedings publication panel in the event asepct are
now linked to the authors and topics aspect.