### PR TITLE
Added a canonical URL link (implements #1151)

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -5,6 +5,8 @@
 
 <meta name="robots" content="index, nofollow">
 
+<link rel="canonical" href="{{ 'https://scholia.toolforge.org' + request.path }}">
+
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='jquery.dataTables.min.css') }}">
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/scholia.css') }}">


### PR DESCRIPTION
At this moment it hardcodes the domain name, but that will be solved after https://github.com/fnielsen/scholia/pull/1037 is merged in.