### PR TITLE
Add academic age to author list #1261

### DIFF
--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -145,6 +145,9 @@ ORDER BY ?order
 SELECT
   # Author order
   ?order
+
+  ?academic_age
+
   # Author item and label
   ?author ?authorUrl ?authorDescription
   
@@ -178,6 +181,15 @@ WHERE {
       BIND(xsd:integer(?order_) AS ?order)
     }
     BIND(CONCAT("https://author-disambiguator.toolforge.org/names_oauth.php?doit=Look+for+author&name=", ENCODE_FOR_URI(?author_)) AS ?authorUrl)
+  }
+  OPTIONAL {
+    SELECT ?author_ (MAX(?academic_age_) AS ?academic_age) {
+      wd:{{ q }} wdt:P50 ?author_ ;
+                   wdt:P577 ?publication_date .
+      ?author_ ^wdt:P50 / wdt:P577 ?other_publication_date .
+      BIND(YEAR(?publication_date) - YEAR(?other_publication_date) AS ?academic_age_)
+    }
+    GROUP BY ?author_
   }
 }
 ORDER BY ?order


### PR DESCRIPTION
Academic age is added to the list of authors on the work
aspect page. It is computed from the first publication date
of the author.