### PR TITLE
404 page specific for unfound DOIs

### DIFF
--- a/scholia/app/templates/404_doi.html
+++ b/scholia/app/templates/404_doi.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block page_content %}
+
+There was no work found with DOI <a href="https://doi.org/{{ doi }}">{{ doi }}</a>.
+
+<script src="{{ url_for('static', filename='js/citation.js') }}"></script>
+
+<h2>QuickStatements</h2>
+
+<pre class="citation-js" data-input="{{ doi }}" data-output-format="quickstatements"></pre>
+
+{% endblock %}

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -711,7 +711,7 @@ def redirect_doi(doi):
     if len(qs) > 0:
         q = qs[0]
         return redirect(url_for('app.show_work', q=q), code=302)
-    return render_template('404.html')
+    return render_template('404_doi.html', doi=doi)
 
 
 @main.route('/event/' + q_pattern)


### PR DESCRIPTION
Similar to the input request in https://github.com/fnielsen/scholia/pull/1312 (IMPORTANT: the first patch is the same) and also using `citation-js`, this page introduces a 404 page for the `/doi/` resolver functionality (for when the DOI is not in Wikidata), and then uses `citation-js` and the DOI to generate QuickStatements. Feedback welcome!

![image](https://user-images.githubusercontent.com/26721/102791146-e032f480-43a6-11eb-92fa-57770831f3de.png)
