### PR TITLE
Add bioRxiv route

### DIFF
--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -13,7 +13,7 @@ from ..rss import (wb_get_author_latest_works, wb_get_venue_latest_works,
 from ..arxiv import metadata_to_quickstatements, string_to_arxiv
 from ..arxiv import get_metadata as get_arxiv_metadata
 from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
-                     github_to_qs,
+                     github_to_qs, biorxiv_to_qs,
                      inchikey_to_qs, issn_to_qs, orcid_to_qs, viaf_to_qs,
                      q_to_class, q_to_dois, random_author, twitter_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -142,10 +142,7 @@ def show_biorxiv(biorxiv_id):
         Rendered HTML.
     """
     qs = biorxiv_to_qs(biorxiv_id)
-    if len(qs) > 0:
-        q = qs[0]
-        return redirect(url_for('app.show_work', q=q), code=302)
-    return render_template('404.html')
+    return _render_qs(qs)
 
 
 @main.route('/arxiv/<arxiv>')
@@ -168,6 +165,10 @@ def show_arxiv(arxiv):
 
     """
     qs = arxiv_to_qs(arxiv)
+    return _render_qs(qs)
+
+
+def _render_qs(qs):
     if len(qs) > 0:
         q = qs[0]
         return redirect(url_for('app.show_work', q=q), code=302)

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -127,6 +127,27 @@ def show_p(p):
     return render_template('property.html', p=p)
 
 
+@main.route('/biorxiv/<biorxiv>')  
+def show_biorxiv(biorxiv_id):
+    """Return HTML rendering for bioRxiv.
+
+    Parameters
+    ----------
+    biorxiv_id : str
+        bioRxiv identifier.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML.
+    """
+    qs = biorxiv_to_qs(biorxiv_id)
+    if len(qs) > 0:
+        q = qs[0]
+        return redirect(url_for('app.show_work', q=q), code=302)
+    return render_template('404.html')
+
+
 @main.route('/arxiv/<arxiv>')
 def show_arxiv(arxiv):
     """Return HTML rendering for arxiv.

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -142,7 +142,7 @@ def show_biorxiv(biorxiv_id):
         Rendered HTML.
     """
     qs = biorxiv_to_qs(biorxiv_id)
-    return _render_qs(qs)
+    return _render_work_qs(qs)
 
 
 @main.route('/arxiv/<arxiv>')
@@ -165,10 +165,10 @@ def show_arxiv(arxiv):
 
     """
     qs = arxiv_to_qs(arxiv)
-    return _render_qs(qs)
+    return _render_work_qs(qs)
 
 
-def _render_qs(qs):
+def _render_work_qs(qs):
     if len(qs) > 0:
         q = qs[0]
         return redirect(url_for('app.show_work', q=q), code=302)
@@ -938,10 +938,7 @@ def redirect_pubmed(pmid):
 
     """
     qs = pubmed_to_qs(pmid)
-    if len(qs) > 0:
-        q = qs[0]
-        return redirect(url_for('app.show_work', q=q), code=302)
-    return render_template('404.html')
+    return _render_work_qs(qs)
 
 
 @main.route('/ncbi-taxon/<taxon>')

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -127,7 +127,7 @@ def show_p(p):
     return render_template('property.html', p=p)
 
 
-@main.route('/biorxiv/<biorxiv>')  
+@main.route('/biorxiv/<biorxiv_id>')
 def show_biorxiv(biorxiv_id):
     """Return HTML rendering for bioRxiv.
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -138,8 +138,36 @@ def arxiv_to_qs(arxiv):
     True
 
     """
-    query = 'select ?work where {{ ?work wdt:P818 "{arxiv}" }}'.format(
-        arxiv=escape_string(arxiv))
+    return _identifier_to_qs('P818', arxiv)
+
+
+def biorxiv_to_qs(biorxiv_id):
+    """Convert bioRxiv ID to Wikidata ID.
+
+    Parameters
+    ----------
+    biorxiv_id : str
+        bioRxiv identifier.
+
+    Returns
+    -------
+    qs : list of str
+        List of string with Wikidata IDs.
+
+    Examples
+    --------
+    >>> biorxiv_to_qs('2020.08.20.259226') == ['Q104920313']
+    True
+
+    """
+    return _identifier_to_qs('P3951', biorxiv_id)
+
+
+def _identifier_to_qs(prop, identifier):
+    query = 'select ?work where {{ ?work wdt:{prop} "{identifier}" }}'.format(
+        prop=prop,
+        identifier=escape_string(identifier),
+    )
 
     url = 'https://query.wikidata.org/sparql'
     params = {'query': query, 'format': 'json'}


### PR DESCRIPTION
This PR adds a route `/biorxiv/<biorxiv_id>` to the application similar to its function for arXiv. Since they work almost identically besides the Wikidata property used, some of the code was abstracted into helper functions and reused for both.