### PR TITLE
Fix #1331: academic age compute on academic works

### DIFF
--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -185,8 +185,10 @@ WHERE {
   OPTIONAL {
     SELECT ?author_ (MAX(?academic_age_) AS ?academic_age) {
       wd:{{ q }} wdt:P50 ?author_ ;
-                   wdt:P577 ?publication_date .
-      ?author_ ^wdt:P50 / wdt:P577 ?other_publication_date .
+                 wdt:P577 ?publication_date .
+      [] wdt:P31 wd:Q13442814 ;
+         wdt:P50 ?author_ ;
+         wdt:P577 ?other_publication_date .
       BIND(YEAR(?publication_date) - YEAR(?other_publication_date) AS ?academic_age_)
     }
     GROUP BY ?author_


### PR DESCRIPTION
Previous SPARQL query only query all works to compute academic age.
Now only scholarly articles are queries. Perhaps other forms of works
should also be added to the query, e.g., academic book, though these
might be difficult to identify.