### PR TITLE
Drop pathways from count on organization

### DIFF
--- a/scholia/app/templates/organization_employees-and-affiliated.sparql
+++ b/scholia/app/templates/organization_employees-and-affiliated.sparql
@@ -1,3 +1,4 @@
+# title: Employees and affiliated with a specified organization
 SELECT
   (SAMPLE(?number_of_works_) AS ?works)
   (SAMPLE(?wikis_) AS ?wikis)
@@ -14,6 +15,9 @@ WITH {
   WHERE {
     INCLUDE %researchers
     OPTIONAL { ?work wdt:P50 ?researcher . }
+
+    # No biological pathways; they skew the statistics too much 
+    MINUS { ?work wdt:P31 wd:Q4915012 } 
   } 
   GROUP BY ?researcher
 } AS %researchers_and_number_of_works


### PR DESCRIPTION
The employee and affiliated list on the organization aspect counted
authorship. This was shewed because of authorships of biological pathways.
Now the authorships of biological pathways are excluded from the counts.

This relates to PR #1318 that used the non-external SPARQL queries