### PR TITLE
scholia/tex.py: Do not escape bibtex key

### DIFF
--- a/scholia/tex.py
+++ b/scholia/tex.py
@@ -315,7 +315,7 @@ def entity_to_bibtex_entry(entity, key=None):
     if key is None:
         entry = u("@Article{%s,\n") % entity['id']
     else:
-        entry = u("@Article{%s,\n") % escape_to_tex(key)
+        entry = u("@Article{%s,\n") % key
     authors = authors_to_bibtex_authors(
         entity_to_authors(entity, return_humanness=True))
     entry += "  author =   {%s},\n" % u" and ".join(authors)


### PR DESCRIPTION
When writing a bib-entry, the key must not be escaped, otherwise
bibtex will not find the key given in the tex file in the bib file.

One example where this breaks without this change is the DOI
10.1007/11925941_2 (due to the underscore). Underscores are special
characters in LaTeX, but not in Bibtex keys, and are allowed in
DOIs.