### PR TITLE
Add initial ChemRxiv support

### DIFF
--- a/scholia/app/templates/work_empty.html
+++ b/scholia/app/templates/work_empty.html
@@ -68,7 +68,7 @@ Scientific articles, conference articles, books, ...
               <dt>
                   <a href="../arxiv/1507.04180">arxiv/1507.04180</a>
               </dt>
-              <dd>Redirect based on a arXiv identifier.</dd>
+              <dd>Redirect based on an arXiv identifier.</dd>
               <dt>
                   <a href="../biorxiv/028522">biorxiv/028522</a>
               </dt>

--- a/scholia/app/templates/work_empty.html
+++ b/scholia/app/templates/work_empty.html
@@ -57,16 +57,26 @@ Scientific articles, conference articles, books, ...
 	    </div>
 	    <div class="card-body">
 	      <dl>
-		<dt>
-		  <a href="../doi/10.1186/S13321-016-0161-3">doi/10.1186/S13321-016-0161-3</a>
-		</dt>
-		<dd>Redirect based on DOI.</dd>
-	      </dl>
-	      <dl>
-		<dt>
-		  <a href="../pubmed/29029422">pubmed/29029422</a>
-		</dt>
-		<dd>Redirect based on PubMed identifier.</dd>
+              <dt>
+                <a href="../doi/10.1186/S13321-016-0161-3">doi/10.1186/S13321-016-0161-3</a>
+              </dt>
+              <dd>Redirect based on a DOI.</dd>
+              <dt>
+                <a href="../pubmed/29029422">pubmed/29029422</a>
+              </dt>
+              <dd>Redirect based on a PubMed identifier.</dd>
+              <dt>
+                  <a href="../arxiv/1507.04180">arxiv/1507.04180</a>
+              </dt>
+              <dd>Redirect based on a arXiv identifier.</dd>
+              <dt>
+                  <a href="../biorxiv/028522">biorxiv/028522</a>
+              </dt>
+              <dd>Redirect based on a bioRxiv identifier.</dd>
+              <dt>
+                  <a href="../chemrxiv/12791954">chemrxiv/12791954</a>
+              </dt>
+              <dd>Redirect based on a ChemRxiv identifier.</dd>
 	      </dl>
 	    </div>
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -13,7 +13,7 @@ from ..rss import (wb_get_author_latest_works, wb_get_venue_latest_works,
 from ..arxiv import metadata_to_quickstatements, string_to_arxiv
 from ..arxiv import get_metadata as get_arxiv_metadata
 from ..query import (arxiv_to_qs, cas_to_qs, atomic_symbol_to_qs, doi_to_qs,
-                     github_to_qs, biorxiv_to_qs,
+                     github_to_qs, biorxiv_to_qs, chemrxiv_to_qs,
                      inchikey_to_qs, issn_to_qs, orcid_to_qs, viaf_to_qs,
                      q_to_class, q_to_dois, random_author, twitter_to_qs,
                      cordis_to_qs, mesh_to_qs, pubmed_to_qs,
@@ -143,6 +143,25 @@ def show_biorxiv(biorxiv_id):
 
     """
     qs = biorxiv_to_qs(biorxiv_id)
+    return _render_work_qs(qs)
+
+
+@main.route('/chemrxiv/<chemrxiv_id>')
+def show_chemrxiv(chemrxiv_id):
+    """Return HTML rendering for ChemRxiv.
+
+    Parameters
+    ----------
+    chemrxiv_id : str
+        ChemRxiv identifier.
+
+    Returns
+    -------
+    html : str
+        Rendered HTML.
+
+    """
+    qs = chemrxiv_to_qs(chemrxiv_id)
     return _render_work_qs(qs)
 
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -2,6 +2,8 @@
 
 Usage:
   scholia.query arxiv-to-q <arxiv>
+  scholia.query biorxiv-to-q <biorxiv>
+  scholia.query chemrxiv-to-q <chemrxiv>
   scholia.query cas-to-q <cas>
   scholia.query atomic-symbol-to-q <symbol>
   scholia.query cordis-to-q <cordis>
@@ -1422,6 +1424,16 @@ def main():
 
     elif arguments['arxiv-to-q']:
         qs = arxiv_to_qs(arguments['<arxiv>'])
+        if len(qs) > 0:
+            print(qs[0])
+
+    elif arguments['biorxiv-to-q']:
+        qs = biorxiv_to_qs(arguments['<biorxiv>'])
+        if len(qs) > 0:
+            print(qs[0])
+
+    elif arguments['chemrxiv-to-q']:
+        qs = chemrxiv_to_qs(arguments['<chemrxiv>'])
         if len(qs) > 0:
             print(qs[0])
 

--- a/scholia/query.py
+++ b/scholia/query.py
@@ -163,6 +163,28 @@ def biorxiv_to_qs(biorxiv_id):
     return _identifier_to_qs('P3951', biorxiv_id)
 
 
+def chemrxiv_to_qs(chemrxiv_id):
+    """Convert ChemRxiv ID to Wikidata ID.
+
+    Parameters
+    ----------
+    chemrxiv_id : str
+        ChemRxiv identifier.
+
+    Returns
+    -------
+    qs : list of str
+        List of string with Wikidata IDs.
+
+    Examples
+    --------
+    >>> chemrxiv_to_qs('12791954') == ['Q98577324']
+    True
+
+    """
+    return _identifier_to_qs('P9262', chemrxiv_id)  
+  
+
 def _identifier_to_qs(prop, identifier):
     query = 'select ?work where {{ ?work wdt:{prop} "{identifier}" }}'.format(
         prop=prop,


### PR DESCRIPTION
Similarly to #1323, this PR adds support for using the newly minted ChemRxiv property (P9262) as a lookup.

Example:  ChemRxiv identifier [13607438](https://chemrxiv.org/articles/preprint/Enantioselective_Conjugate_Addition_of_Catalytically_Generated_Zinc_Homoenolate/13607438) points to [Q104931192](https://www.wikidata.org/wiki/Q104931192). There aren't a ton of identifiers pre-populated, but I have written a script with the Wikidata Integrator that can add the rest.
