### PR TITLE
Fix #1258 new redirect for arxiv-to-quickstatements

### DIFF
--- a/scholia/app/templates/arxiv_to_quickstatements.html
+++ b/scholia/app/templates/arxiv_to_quickstatements.html
@@ -40,10 +40,12 @@ ID is found in Wikidata. However, note that new items may not be immediately fou
 
 {% if quickstatements %}
 
-<div id="quickstatements"><pre>{{ quickstatements }} </pre></div>
+<div id="quickstatements"><pre>{{ quickstatements }}</pre></div>
 
-<a href="https://wikidata-todo.toolforge.org/quick_statements.php?list={{ quickstatements | urlencode }}">Forward to Magnus Manske's quickstatements</a>
-
+<a href="https://quickstatements.toolforge.org/#/v1={{ quickstatements | replace('\t', '|') | replace('\n', '||') | urlencode | replace('/','%2F') }}">
+  <button class="btn btn-primary">Submit to Quickstatements ↗</button>
+</a>
+  
 {% endif %}
 
 

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -237,6 +237,15 @@ def show_arxiv_to_quickstatements():
                                arxiv=arxiv)
 
     quickstatements = metadata_to_quickstatements(metadata)
+
+    # For Quickstatements Version 2 in URL components,
+    # TAB and newline should be replace by | and ||
+    # https://www.wikidata.org/wiki/Help:QuickStatements
+    # Furthermore the '/' also needs to be encoded, but Jinja2 urlencode does
+    # not encode that character.
+    # https://github.com/pallets/jinja/issues/515
+    # Here, we let jinja2 handle the encoding rather than adding an extra
+    # parameter
     return render_template('arxiv_to_quickstatements.html',
                            arxiv=arxiv, quickstatements=quickstatements)
 


### PR DESCRIPTION
The old Quickstatement did no longer work and this commit change
so the link goes to the new Quickstatement tool (V2).
The link is also changed to a button.