### PR TITLE
Fix #1349 so project header is showing

### DIFF
--- a/scholia/app/templates/project.html
+++ b/scholia/app/templates/project.html
@@ -21,7 +21,7 @@
 
 
 {% block page_content %}
-<h1 id="project-header">Project</h1>
+<h1 id="h1">Project</h1>
 
 <div id="intro"></div>
 


### PR DESCRIPTION
A change in the id for the H1 tag meant that the title of the project no
longer was showing. This fix change the name back.