### PR TITLE
Fix #1304 security issue for lxml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.5]
+        python: [2.7, 3.5, 3.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install lxml dependencies
-        run: sudo apt install libxml2-dev libxsmt-dev
+        run: sudo apt install libxml2-dev libxslt-dev
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install lxml dependencies
+        run: sudo apt install libxml2-dev libxsmt-dev
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
+      - name: Install Cython for lxml installation
+        run: pip install Cython
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ docopt
 flask
 Flask-Bootstrap
 flask-mwoauth>=0.1.14
-lxml
+lxml>=4.6.3
 requests
 simplejson
 werkzeug>=0.9

--- a/scholia/tex.py
+++ b/scholia/tex.py
@@ -36,7 +36,12 @@ from os.path import splitext
 import re
 import unicodedata
 
-from six import ensure_text, u
+from six import u
+try:
+    from six import ensure_text
+except ImportError:
+    # enture_text is not available in Python3.7 apparently
+    ensure_text = str
 
 from .api import (
     entity_to_authors, entity_to_classes, entity_to_doi,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, pydocstyle, py27, py35
+envlist = flake8, pydocstyle, py27, py35, py37
 
 
 [testenv:py27]


### PR DESCRIPTION
Vulnerability for lxml, see:
https://pypi.org/project/lxml/
Remediation: Upgrade lxml to version 4.6.3 or higher.