### PR TITLE
Fix #1390 scraping OJS author

### DIFF
--- a/scholia/scrape/ojs.py
+++ b/scholia/scrape/ojs.py
@@ -305,7 +305,7 @@ def scrape_paper_from_url(url):
             for author_element in
             tree.xpath("//meta[@name='DC.Creator.PersonalName']")
         ]
-        if len(authors) > 1:
+        if len(authors) > 0:
             entry['authors'] = authors
 
     title = _fields_to_content(['citation_title', 'DC.Title'])


### PR DESCRIPTION
OJS author was in some instances not extracting the author name if
there was only one author.