### PR TITLE
Added a <meta> element for Unpaywall support

### DIFF
--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -101,7 +101,7 @@ sparqlToIframe(`# tool: scholia
 
 	 try {
 	     var doi = item.claims.P356[0].mainsnak.datavalue.value;
-	     detailsList.push( '<meta name="citation_doi" content="' + doi + '"/>');
+	     $("head").append( '<meta name="citation_doi" content="' + doi + '"/>' );
 	 }
 	 catch(e) {}
 

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -100,6 +100,12 @@ sparqlToIframe(`# tool: scholia
 	 catch(e) {}
 
 	 try {
+	     var doi = item.claims.P356[0].mainsnak.datavalue.value;
+	     detailsList.push( '<meta name="citation_doi" content="' + doi + '"/>');
+	 }
+	 catch(e) {}
+
+	 try {
 	     $( '#details' ).append( detailsList.join( " | " ) );
 	 }
 	 catch(e) {}


### PR DESCRIPTION
It works by adding a `<meta>` element, which is the "semantic" data needed by the Unpaywall extension. See https://support.unpaywall.org/support/solutions/articles/44002172370-how-do-i-make-the-unpaywall-extension-work-on-my-site-

In action:

![image](https://user-images.githubusercontent.com/26721/112873219-a4a07880-90c1-11eb-98e9-c37d6d7578f9.png)
