### PR TITLE
Fix #1420: Change Wikipedia search

### DIFF
--- a/scholia/app/templates/work_wikipedia-mentions.sparql
+++ b/scholia/app/templates/work_wikipedia-mentions.sparql
@@ -1,32 +1,72 @@
-SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel WHERE {
+SELECT
+  ?title ?titleUrl
+  ?wikipedia ?wikipediaLabel
+  ?item ?itemLabel ?itemDescription 
+WHERE {
   {
-    SELECT ?title_ ?titleUrl ?wikipedia {
+    SELECT ?title_ ?titleUrl ?item ?wikipedia {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "da.wikipedia.org" ;
-                        wikibase:api "Search" ;
-                        mwapi:srsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
-                        mwapi:srlimit "200" .
+                        wikibase:api "Generator" ;
+			mwapi:generator "search" ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
+	?item wikibase:apiOutputItem mwapi:item .
       }
-      BIND(URI(CONCAT("https://da.wikipedia.org/wiki/", ENCODE_FOR_URI(?title_))) AS ?titleUrl)
+      BIND(URI(CONCAT("https://da.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
       BIND(wd:Q181163 AS ?wikipedia)
     } 
   }
   UNION
   {
-    SELECT ?title_ ?titleUrl ?wikipedia {
+    SELECT ?title_ ?titleUrl ?item ?wikipedia {
+      SERVICE wikibase:mwapi {
+        bd:serviceParam wikibase:endpoint "de.wikipedia.org" ;
+                        wikibase:api "Generator" ;
+			mwapi:generator "search" ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrlimit "200" .
+        ?title_ wikibase:apiOutput mwapi:title .
+	?item wikibase:apiOutputItem mwapi:item .
+      }
+      BIND(URI(CONCAT("https://de.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
+      BIND(wd:Q48183 AS ?wikipedia)
+    }     
+  }
+  UNION
+  {
+    SELECT ?title_ ?titleUrl ?item ?wikipedia {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "en.wikipedia.org" ;
-                        wikibase:api "Search" ;
-                        mwapi:srsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
-                        mwapi:srlimit "200" .
+                        wikibase:api "Generator" ;
+			mwapi:generator "search" ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
+	?item wikibase:apiOutputItem mwapi:item .
       }
-      BIND(URI(CONCAT("https://en.wikipedia.org/wiki/", ENCODE_FOR_URI(?title_))) AS ?titleUrl)
+      BIND(URI(CONCAT("https://en.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
       BIND(wd:Q328 AS ?wikipedia)
     }     
   }
+  UNION
+  {
+    SELECT ?title_ ?titleUrl ?item ?wikipedia {
+      SERVICE wikibase:mwapi {
+        bd:serviceParam wikibase:endpoint "fr.wikipedia.org" ;
+                        wikibase:api "Generator" ;
+			mwapi:generator "search" ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrlimit "200" .
+        ?title_ wikibase:apiOutput mwapi:title .
+	?item wikibase:apiOutputItem mwapi:item .
+      }
+      BIND(URI(CONCAT("https://fr.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
+      BIND(wd:Q8447 AS ?wikipedia)
+    }     
+  }
   hint:Prior hint:runFirst "true" .
-  BIND(CONCAT(?title_, " ↗") AS ?title)
+  BIND(CONCAT(?title_, "&nbsp;↗") AS ?title)
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" . }
 } 


### PR DESCRIPTION
SPARQL query has been extended and fixed.
Now the Wikidata item is also included in the table as well as the description.
Whitespace is changed to underscore for the Wikipedia title.
German and French Wikipedia are now also searched.