### PR TITLE
Fix #1447 add editor recent publications

### DIFF
--- a/scholia/app/templates/event_recent-publications.sparql
+++ b/scholia/app/templates/event_recent-publications.sparql
@@ -21,6 +21,11 @@ WITH {
       # author
       ?person ^wdt:P50 / wdt:P1433 / wdt:P4745 wd:{{ q }} .
     }
+    UNION
+    {
+      # editor of proceedings
+      ?person ^wdt:P98 / wdt:P4745 wd:{{ q }} .
+    }
   }
 } AS %people  
 WITH {


### PR DESCRIPTION
The recent publications for people associated with an event now
also takes the publications from the editor of the proceedings.