### PR TITLE
Added retraction info

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -161,6 +161,53 @@ function sparqlToDataTable(sparql, element, options={}) {
 }
 
 
+function sparqlToDataTablePost(sparql, element, filename, options={}) {
+    // Options: linkPrefixes={}, paging=true
+    var linkPrefixes = (typeof options.linkPrefixes === 'undefined') ? {} : options.linkPrefixes;
+    var linkSuffixes = (typeof options.linkSuffixes === 'undefined') ? {} : options.linkSuffixes;
+    var paging = (typeof options.paging === 'undefined') ? true : options.paging;
+    var sDom = (typeof options.sDom === 'undefined') ? 'lfrtip' : options.sDom;
+    var url = "https://query.wikidata.org/sparql";
+
+    $.post(url, data={query: sparql}, function(response, textStatus) {
+        var simpleData = sparqlDataToSimpleData(response);
+
+        convertedData = convertDataTableData(simpleData.data, simpleData.columns, linkPrefixes=linkPrefixes, linkSuffixes=linkSuffixes);
+        columns = [];
+        for ( i = 0 ; i < convertedData.columns.length ; i++ ) {
+            var column = {
+                data: convertedData.columns[i],
+                title: capitalizeFirstLetter(convertedData.columns[i]).replace(/_/g, "&nbsp;"),
+                defaultContent: "",
+            }
+            columns.push(column)
+        }
+
+        var table = $(element).DataTable({
+            data: convertedData.data,
+            columns: columns,
+            lengthMenu: [[10, 25, 100, -1], [10, 25, 100, "All"]],
+            ordering: true,
+            order: [],
+            paging: paging,
+            sDom: sDom,
+        });
+
+        $(element).append(
+            '<caption><span style="float:left; font-size:smaller;"><a href="https://query.wikidata.org/#' +
+                encodeURIComponent(sparql) +
+                '">Wikidata Query Service</a></span>' +
+                '<span style="float:right; font-size:smaller;"><a href="https://github.com/fnielsen/scholia/blob/master/scholia/app/templates/' +
+                filename + '">' +
+                filename.replace("_", ": ") +
+                '</a></span></caption>'
+        );
+    }, "json");
+};
+
+
+
+
 function sparqlToDataTable2(sparql, element, filename, options={}) {
     // Options: linkPrefixes={}, paging=true
     var linkPrefixes = (typeof options.linkPrefixes === 'undefined') ? {} : options.linkPrefixes;

--- a/scholia/app/templates/base.html
+++ b/scholia/app/templates/base.html
@@ -1,5 +1,14 @@
 {% extends "bootstrap-base.html" %}
 
+{% macro sparql_to_table_post(panel, options={}) -%}
+// {{ panel }} table
+sparqlToDataTablePost(`# tool: scholia
+{% include aspect + '_' + panel + '.sparql' %}
+`,
+"#{{ panel }}-table", "{{ aspect }}_{{ panel }}.sparql",
+options={{ options | tojson }});
+{%- endmacro %}
+
 {% macro sparql_to_table(panel, options={}) -%}
 // {{ panel }} table
 sparqlToDataTable2(`# tool: scholia

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -4,7 +4,7 @@
 
 {% block in_ready %}
 
-{{ sparql_to_table('data') }}
+{{ sparql_to_table_post('data') }}
 {{ sparql_to_table('list-of-authors') }}
 {{ sparql_to_table('related-works') }}
 {{ sparql_to_table('citations') }}

--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -138,5 +138,24 @@ WHERE {
     ?work wdt:P953 ?valueUrl .
     BIND(CONCAT(STR(?valueUrl), " ↗") AS ?value)
   }
+  UNION
+  {
+    BIND(13 AS ?order)
+    BIND("Retracted" AS ?description)
+    { ?work wdt:P31 wd:Q45182324 . }
+    UNION
+    { ?work wdt:P793 wd:Q7316896 . }
+  }
+  UNION
+  {
+    BIND(14 AS ?order)
+    BIND("Retracted by" AS ?description)
+    ?work wdt:P5824 ?iri .
+    BIND(SUBSTR(STR(?iri), 32) AS ?q) 
+    ?iri rdfs:label ?value_string . 
+    FILTER (LANG(?value_string) = 'en')
+    BIND(COALESCE(?value_string, ?q) AS ?value)
+    BIND(CONCAT("../work/", ?q) AS ?valueUrl)
+  }
 } 
 ORDER BY ?order


### PR DESCRIPTION
It uses the same three different ways Wikidata currently can mark an article as retracted (two in one UNION clause). The output looks like:

![image](https://user-images.githubusercontent.com/26721/121477859-a2fc0680-c9c8-11eb-9698-c1f897767e4c.png)
